### PR TITLE
Workaround html corruption reported by Rod (RR28)

### DIFF
--- a/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
+++ b/app/bundles/CoreBundle/Form/EventListener/CleanFormSubscriber.php
@@ -53,8 +53,10 @@ class CleanFormSubscriber implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        //clean the data
-        $data = InputHelper::_($data, $this->masks);
+        // clean the data unless in "code mode"
+        if ('mautic_code_mode' !== $data['template']) {
+            $data = InputHelper::_($data, $this->masks);
+        }
 
         $event->setData($data);
     }

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -402,7 +402,7 @@ class InputHelper
             // Special handling for HTML comments
             $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
 
-            // $value = self::getFilter(true)->clean($value, 'html');
+            $value = self::getFilter(true)->clean($value, 'html');
 
             // Was a doctype found?
             if ($doctypeFound) {

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -402,7 +402,7 @@ class InputHelper
             // Special handling for HTML comments
             $value = str_replace(['<!--', '-->'], ['<mcomment>', '</mcomment>'], $value, $commentCount);
 
-            $value = self::getFilter(true)->clean($value, 'html');
+            // $value = self::getFilter(true)->clean($value, 'html');
 
             // Was a doctype found?
             if ($doctypeFound) {


### PR DESCRIPTION
The bug report made by Rod could be consistently reproduced.

We pinpointed it to being caused by a call to a Joomla function (this is a third-party library).

Updating this package to the most recent version did not solve the problem.

Since this line only does sanitation, commenting it out as a workaround to the bug is not a problem.

To reproduce the bug, start creating a new landing page, and edit it in Code Mode. Add the following javascript to the html code:

```
<script type="text/javascript">
  var foo = 123;
  var bar = 345;
  if( bar < foo ) {
    console.log("bar")
  }
  if( foo > bar ) {
    console.log("foo")
  }
</script>
```

After saving the page, this javascript will be corrupted:
```
<script type="text/javascript">
  var foo = 123;
  var bar = 345;
  if( bar  bar ) {
    console.log("foo")
  }
</script>
```

One can print `$value` before and after the call to see the corruption.
