### PR TITLE
CSI integration plugin: new add/remove from CSI list plugin (RR3)

### DIFF
--- a/plugins/MauticMauldinCSIBundle/CSIEvents.php
+++ b/plugins/MauticMauldinCSIBundle/CSIEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle;
+
+/**
+ * Class CSIEvents
+ * Events available for MauticMauldinCSIBundle.
+ */
+final class CSIEvents
+{
+    /**
+     * The mauldin.click.on_campaign_trigger_decision event is fired when the campaign action triggers.
+     *
+     * The event listener receives a
+     * Mautic\CampaignBundle\Event\CampaignExecutionEvent
+     *
+     * @var string
+     */
+    const ON_CAMPAIGN_TRIGGER_ACTION = 'mauldin.csi.on_campaign_trigger_decision';
+
+    const ON_MODIFY_CSI_LIST = 'mauldin.csi.on_modify_csi_list';
+}

--- a/plugins/MauticMauldinCSIBundle/Command/ProcessCSIOptListCommand.php
+++ b/plugins/MauticMauldinCSIBundle/Command/ProcessCSIOptListCommand.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Command;
+
+use Mautic\CoreBundle\Command\ModeratedCommand;
+use MauticPlugin\MauticMauldinCSIBundle\Exception\CSIAPIException;
+use MauticPlugin\MauticMauldinCSIBundle\Helper\XmlParserHelper;
+use MauticPlugin\MauticMauldinEmailScalabilityBundle\MessageQueue\ChannelHelper;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CLI command to process the e-mail queue.
+ */
+class ProcessCSIOptListCommand extends ModeratedCommand
+{
+    private $username;
+    private $password;
+    private $host;
+    const CSI_ENDPOINT = '/api/v2/listmanager/';
+    const CSI_OPT_OUT  = self::CSI_ENDPOINT.'optOut';
+    const CSI_OPT_IN   = self::CSI_ENDPOINT.'optIn';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('mauldin:csi:lists:update')
+            ->setDescription('Processes CSI Queue actions and make API Calls')
+            ->setHelp(<<<'EOT'
+The <info>%command.name%</info> command is used to process the application's e-mail queue
+
+<info>php %command.full_name%</info>
+EOT
+            );
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getContainer();
+
+        $this->username = $container->getParameter('mautic.csiapi_username');
+        $this->password = $container->getParameter('mautic.csiapi_password');
+        $this->host     = $container->getParameter('mautic.csiapi_host');
+        $dispatcher     = $container->get('event_dispatcher');
+
+        /** @var ChannelHelper $channelHelper */
+        $channelHelper = $container->get('mauldin.scalability.message_queue.channel_helper');
+        $queue         = $channelHelper->declareQueue('csi_list');
+
+        $callback = function ($msg) {
+            $this->process($msg);
+        };
+
+        // TODO: improve message retry functionality for now its is just going to retry forever until the message is sent
+        // We can implement TTL expiring or dead lettered messages as specified in rabbitmq documentation
+        $queue->consume($callback);
+
+        // Timeout in 10 seconds  and give up on $max_timeout
+        $max_timeout     = 10;
+        $timeout_counter = 0;
+
+        while ($queue->hasChannelCallbacks() && ($timeout_counter < $max_timeout)) {
+            try {
+                $queue->wait(0.2);
+                $timeout_counter = 0;
+            } catch (AMQPTimeoutException $e) {
+                $output->writeln('Wait timeout counter '.$timeout_counter);
+                $timeout_counter = $timeout_counter + 1;
+            }
+        }
+
+        return 0;
+    }
+
+    private function get($url, $data = false)
+    {
+        $curl = curl_init();
+
+        // build request url
+        if ($data) {
+            $url = sprintf('%s?%s', $url, http_build_query($data));
+        }
+
+        // Header Configuration
+        $auth = $this->username.':'.$this->password;
+        curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        curl_setopt($curl, CURLOPT_USERPWD, $auth);
+        curl_setopt($curl, CURLOPT_URL, $url);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLINFO_HEADER_OUT, true);
+
+        //Make GET Call
+        $result   = curl_exec($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+        switch ($httpCode) {
+            case 200:
+                return $result;
+                break;
+            case 404:
+                throw new CSIAPIException("Can't reach url: ".$url, 404);
+                break;
+            default:
+                throw new CSIAPIException('HTTP Request failed: ', $httpCode);
+                break;
+
+        }
+    }
+
+    /**
+     * @param string $email
+     * @param array  $list
+     *
+     * @return
+     */
+    public function optIn($email, $list)
+    {
+        $url      = $this->host.self::CSI_OPT_IN;
+        $data     = ['email' => $email, 'code' => $list];
+        $response = $this->get($url, $data);
+        $result   = XmlParserHelper::arrayFromXml($response);
+        if (!$result['response']['success']) {
+            $result['request'] = ['url' => $url, 'data' => $data];
+            $result['time']    = new \DateTime();
+            throw new CSIAPIException('CSI API Exception: request to "'.$url.'" failed', 200, $result);
+        }
+    }
+
+    /**
+     * @param string $email
+     * @param array  $list
+     *
+     * @return
+     */
+    public function optOut($email, $list)
+    {
+        $url      = $this->host.self::CSI_OPT_OUT;
+        $data     = ['email' => $email, 'code' => $list];
+        $response = $this->get($url, $data);
+        $result   = XmlParserHelper::arrayFromXml($response);
+        if (!$result['response']['success']) {
+            $result['request'] = ['url' => $url, 'data' => $data];
+            $result['time']    = new \DateTime();
+            throw new CSIAPIException('CSI API Exception: request to "'.$url.'" failed', 200, $result);
+        }
+    }
+
+    private function process($msg)
+    {
+        try {
+            $message = unserialize($msg->body);
+            var_dump($message);
+            if (isset($message['add'])) {
+                $this->optIn($message['add']['lead'], $message['add']['list']);
+            }
+            if (isset($message['remove'])) {
+                $this->optOut($message['remove']['lead'], $message['remove']['list']);
+            }
+            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+        } catch (CSIAPIException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    // Log api errors to a file in json format
+                    $file = fopen('app/logs/csiapi-opt.log', 'a');
+                    fwrite($file, json_encode($e->getErrorData())."\n");
+                    fclose($file);
+                    // Remove api return errors from queue
+                    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+                    break;
+                default:
+                    // Don't acknowledge the message in the other case
+                    // So the message is not removed from the queue
+            }
+        }
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Config/config.php
+++ b/plugins/MauticMauldinCSIBundle/Config/config.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+return [
+    'name'        => 'Mauldin CSI',
+    'description' => 'CSI Integration Plugin',
+    'version'     => '1.0',
+    'author'      => 'Brick Abode',
+
+    'services' => [
+        'events' => [
+            'mauldin.csi.campaignbundle.subscriber' => [
+                'class'     => 'MauticPlugin\MauticMauldinCSIBundle\EventListener\CampaignSubscriber',
+                'arguments' => [
+                    'mautic.mauldin.csi.csi',
+                ],
+            ],
+            'mauldin.csi.formbundle.subscriber' => [
+                'class'     => 'MauticPlugin\MauticMauldinCSIBundle\EventListener\FormSubscriber',
+                'arguments' => [
+                    'mautic.mauldin.csi.csi',
+                ],
+            ],
+        ],
+        'model' => [
+            'mautic.mauldin.csi.csi' => [
+                'class'     => 'MauticPlugin\MauticMauldinCSIBundle\Model\CSIModel',
+                'arguments' => [
+                    'mautic.lead.model.list',
+                    '@mauldin.scalability.message_queue.channel_helper',
+                ],
+            ],
+        ],
+        'other' => [
+            'mautic.mauldin.csi.rabbitmq_connection' => [
+                'class'     => 'PhpAmqpLib\Connection\AMQPStreamConnection',
+                'arguments' => [
+                    '%mautic.rabbitmq_host%',
+                    '%mautic.rabbitmq_port%',
+                    '%mautic.rabbitmq_username%',
+                    '%mautic.rabbitmq_password%',
+                ],
+            ],
+        ],
+        'forms' => [
+            'mautic.form.type.csilist_choices' => [
+                'class'     => 'MauticPlugin\MauticMauldinCSIBundle\Form\Type\CSIListType',
+                'arguments' => ['mautic.factory'],
+                'alias'     => 'csilist_choices',
+            ],
+            'mautic.form.type.csilist_action' => [
+                'class' => 'MauticPlugin\MauticMauldinCSIBundle\Form\Type\CSIListActionType',
+                'alias' => 'csilist_action',
+            ],
+        ],
+
+    ],
+];

--- a/plugins/MauticMauldinCSIBundle/EventListener/CampaignSubscriber.php
+++ b/plugins/MauticMauldinCSIBundle/EventListener/CampaignSubscriber.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\EventListener;
+
+use Mautic\CampaignBundle\CampaignEvents;
+use Mautic\CampaignBundle\Event\CampaignBuilderEvent;
+use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\CampaignBundle\Model\EventModel;
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use MauticPlugin\MauticMauldinCSIBundle\CSIEvents;
+use MauticPlugin\MauticMauldinCSIBundle\Model\CSIModel;
+
+/**
+ * Class CampaignSubscriber.
+ */
+class CampaignSubscriber extends CommonSubscriber
+{
+    /**
+     * @var string Name used for the CampaignBuilder event
+     */
+    const OPT_LIST_ACTION = 'mauldin.list_option_action';
+
+    /**
+     * @var EventModel
+     */
+    protected $csiModel;
+
+    /**
+     * CampaignSubscriber constructor.
+     *
+     * @param EventModel $eventModel
+     */
+    public function __construct(CSIModel $csiModel)
+    {
+        $this->csiModel = $csiModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            CampaignEvents::CAMPAIGN_ON_BUILD     => ['onCampaignBuild', 0],
+            CSIEvents::ON_CAMPAIGN_TRIGGER_ACTION => ['onCampaignTriggerAction', 0],
+        ];
+    }
+
+    /**
+     * @param CampaignBuilderEvent $event
+     */
+    public function onCampaignBuild(CampaignBuilderEvent $event)
+    {
+        $event->addAction(
+            self::OPT_LIST_ACTION,
+            [
+                'label'       => 'mauldin.csi.campaign.event.list_optlist_action',
+                'description' => 'mauldin.csi.campaign.event.list_optlist_action_description',
+                'eventName'   => CSIEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+                'formType'    => 'csilist_action',
+            ]
+        );
+    }
+
+    /**
+     * @param CampaignExecutionEvent $event
+     */
+    public function onCampaignTriggerAction(CampaignExecutionEvent $event)
+    {
+        if (!$event->checkContext(self::OPT_LIST_ACTION)) {
+            return null;
+        }
+
+        $addTo      = $event->getConfig()['addToLists'];
+        $removeFrom = $event->getConfig()['removeFromLists'];
+
+        $lead              = $event->getLead();
+        $somethingHappened = false;
+
+        if (!empty($addTo)) {
+            $this->csiModel->addToList($lead, $addTo);
+            $somethingHappened = true;
+        }
+
+        if (!empty($removeFrom)) {
+            $this->csiModel->removeFromList($lead, $removeFrom);
+            $somethingHappened = true;
+        }
+
+        return $event->setResult($somethingHappened);
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\EventListener;
+
+use Mautic\CoreBundle\EventListener\CommonSubscriber;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\FormBundle\Event\FormBuilderEvent;
+use Mautic\FormBundle\Event\SubmissionEvent;
+use Mautic\FormBundle\FormEvents;
+use MauticPlugin\MauticMauldinCSIBundle\CSIEvents;
+use MauticPlugin\MauticMauldinCSIBundle\Model\CSIModel;
+
+/**
+ * Class FormSubscriber.
+ */
+class FormSubscriber extends CommonSubscriber
+{
+    /**
+     * @var EmailModel
+     */
+    protected $csiModel;
+
+    /**
+     * FormSubscriber constructor.
+     *
+     * @param EmailModel $emailModel
+     */
+    public function __construct(CSIModel $csiModel)
+    {
+        $this->csiModel = $csiModel;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::FORM_ON_BUILD     => ['onFormBuilder', 0],
+            CSIEvents::ON_MODIFY_CSI_LIST => ['onChangeLists', 0],
+        ];
+    }
+
+    /**
+     * Add a lead generation action to available form submit actions.
+     *
+     * @param FormBuilderEvent $event
+     */
+    public function onFormBuilder(FormBuilderEvent $event)
+    {
+
+        //add to lead list
+        $action = [
+            'group'             => 'mautic.lead.lead.submitaction',
+            'label'             => 'mauldin.lead.lead.events.changecsilist',
+            'description'       => 'mauldin.lead.lead.events.changecsilist_descr',
+            'formType'          => 'csilist_action',
+            'eventName'         => CSIEvents::ON_MODIFY_CSI_LIST,
+            'allowCampaignForm' => true,
+        ];
+        $event->addSubmitAction('lead.changecsilist', $action);
+    }
+
+    /**
+     * @param $action
+     * @param $factory
+     */
+    public function onChangeLists(SubmissionEvent $event)
+    {
+        $properties = $event->getActionConfig();
+
+        /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
+        $lead       = $event->getLead();
+        $addTo      = $properties['addToLists'];
+        $removeFrom = $properties['removeFromLists'];
+
+        if (!empty($addTo)) {
+            $this->csiModel->addToList($lead, $addTo);
+        }
+
+        if (!empty($removeFrom)) {
+            $this->csiModel->removeFromList($lead, $removeFrom);
+        }
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Exception/CSIAPIException.php
+++ b/plugins/MauticMauldinCSIBundle/Exception/CSIAPIException.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Exception;
+
+use Throwable;
+
+class CSIAPIException extends \Exception
+{
+    private $errorData;
+    public function __construct($message = '', $code = 0, $errorData = null, Throwable $previous = null)
+    {
+        $this->errorData = $errorData;
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getErrorData()
+    {
+        return $this->errorData;
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Form/Type/CSIListActionType.php
+++ b/plugins/MauticMauldinCSIBundle/Form/Type/CSIListActionType.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class ListActionType.
+ */
+class CSIListActionType extends AbstractType
+{
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add(
+            'addToLists',
+            'csilist_choices',
+            [
+                'label'      => 'mauldin.csi.lead.events.addtolists',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class' => 'form-control',
+                ],
+                'multiple' => true,
+                'expanded' => false,
+            ]);
+
+        $builder->add(
+            'removeFromLists',
+            'csilist_choices',
+            [
+                'label'      => 'mauldin.csi.lead.events.removefromlists',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class' => 'form-control',
+                ],
+                'multiple' => true,
+                'expanded' => false,
+            ]);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'csilist_action';
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Form/Type/CSIListType.php
+++ b/plugins/MauticMauldinCSIBundle/Form/Type/CSIListType.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Form\Type;
+
+use Mautic\CoreBundle\Factory\MauticFactory;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class CSIListType extends AbstractType
+{
+    private $model;
+
+    /**
+     * @param MauticFactory $factory
+     */
+    public function __construct(MauticFactory $factory)
+    {
+        $this->model = $factory->getModel('lead.list');
+    }
+
+    /**
+     * @param OptionsResolverInterface $resolver
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        /** @var \Mautic\LeadBundle\Model\ListModel $model */
+        $model = $this->model;
+        $resolver->setDefaults([
+            'choices' => function (Options $options) use ($model) {
+                $lists = (empty($options['global_only'])) ? $model->getUserLists() : $model->getGlobalLists();
+
+                $choices = [];
+
+                foreach ($lists as $l) {
+                    if (0 === strpos($l['alias'], 'csi-free-')) {
+                        $choices[$l['id']] = $l['name'];
+                    }
+                }
+
+                return $choices;
+            },
+            'global_only' => false,
+            'required'    => false,
+        ]);
+    }
+
+    /**
+     * @return null|string|\Symfony\Component\Form\FormTypeInterface
+     */
+    public function getParent()
+    {
+        return 'choice';
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'csilist_choices';
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Helper/XmlParserHelper.php
+++ b/plugins/MauticMauldinCSIBundle/Helper/XmlParserHelper.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ *
+ * Note that this file was taken from the CSI codebase:
+ *
+ *   csi/application/third_party/casey/lib/Xml/Parser.php
+ *
+ * The only changes are:
+ *   - header text;
+ *   - name of the class;
+ *   - whitespace and linting.
+ *
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Helper;
+
+use SimpleXMLIterator;
+
+/**
+ * Parses incoming Xml into arrays using PHP's
+ * built-in SimpleXML, and its extension via
+ * Iterator, SimpleXMLIterator
+ *
+ */
+class XmlParserHelper
+{
+    private static $_xmlRoot;
+    private static $_responseType;
+
+    /**
+     * sets up the SimpleXMLIterator and starts the parsing
+     * @access public
+     * @param string $xml
+     * @return array array mapped to the passed xml
+     */
+    public static function arrayFromXml($xml)
+    {
+        // SimpleXML provides the root information on construct
+        libxml_clear_errors();
+        libxml_use_internal_errors(true);
+        $iterator = new SimpleXMLIterator($xml);
+        if ($iterator === false) {
+            $errors = libxml_get_errors();
+            throw new Exception("Invalid XML: " . implode(PHP_EOL, $errors));
+        }
+
+        $xmlRoot = $iterator->getName();
+        $type = $iterator->attributes()->type;
+        self::$_xmlRoot = $iterator->getName();
+        self::$_responseType = $type;
+        // return the mapped array with the root element as the header
+        return array($xmlRoot => self::_iteratorToArray($iterator));
+    }
+
+    /**
+     * processes SimpleXMLIterator objects recursively
+     *
+     * @access protected
+     * @param object $iterator
+     * @return array xml converted to array
+     */
+    private static function _iteratorToArray($iterator)
+    {
+        $xmlArray = array();
+        $value = null;
+        // rewind the iterator and check if the position is valid
+        // if not, return the string it contains
+        $iterator->rewind();
+        if (!$iterator->valid()) {
+            return self::_typecastXmlValue($iterator);
+        }
+        for ($iterator->rewind(); $iterator->valid(); $iterator->next()) {
+            $tmpArray = null;
+            $value = null;
+            // get the attribute type string for use in conditions below
+            $attributeType = $iterator->attributes()->type;
+            // extract the parent element via xpath query
+            $parentElement = $iterator->xpath($iterator->key() . '/..');
+            if ($parentElement[0] instanceof SimpleXMLIterator) {
+                $parentElement = $parentElement[0];
+                $parentKey = $parentElement->getName();
+            } else {
+                $parentElement = null;
+            }
+            $key = $iterator->key();
+            // process children recursively
+            if ($iterator->hasChildren()) {
+                // return the child elements
+                $value = self::_iteratorToArray($iterator->current());
+                // if the element is an array type,
+                // use numeric keys to allow multiple values
+                if ($attributeType != 'array') {
+                    $tmpArray[$key] = $value;
+                }
+            } else {
+                // cast values according to attributes
+                $tmpArray[$key] = self::_typecastXmlValue($iterator->current());
+            }
+            // set the output string
+            $output = isset($value) ? $value : $tmpArray[$key];
+            // determine if there are multiple tags of this name at the same level
+            if (isset($parentElement) &&
+                ($parentElement->attributes()->type == 'collection') &&
+                $iterator->hasChildren()) {
+                $xmlArray[$key][] = $output;
+                continue;
+            }
+            // if the element was an array type, output to a numbered key
+            // otherwise, use the element name
+            if ($attributeType == 'array') {
+                $xmlArray[] = $output;
+            } else {
+                $xmlArray[$key] = $output;
+            }
+        }
+        return $xmlArray;
+    }
+
+    /**
+     * typecast xml value based on attributes
+     * @param object $valueObj SimpleXMLElement
+     * @return mixed value for placing into array
+     */
+    private static function _typecastXmlValue($valueObj)
+    {
+        // get the element attributes
+        $attribs = $valueObj->attributes();
+        // the element is null, so jump out here
+        if (isset($attribs->nil) && $attribs->nil) {
+            return null;
+        }
+        // switch on the type attribute
+        // switch works even if $attribs->type isn't set
+        switch ($attribs->type) {
+            case 'datetime':
+                return self::_timestampToUTC((string) $valueObj);
+                break;
+            case 'date':
+                return new DateTime((string)$valueObj);
+                break;
+            case 'integer':
+                return (int) $valueObj;
+                break;
+            case 'boolean':
+                $value =  (string) $valueObj;
+                // look for a number inside the string
+                if(is_numeric($value)) {
+                    return (bool) $value;
+                } else {
+                    // look for the string "true", return false in all other cases
+                    return ($value != "true") ? FALSE : TRUE;
+                }
+                break;
+            case 'array':
+                return array();
+            default:
+                return (string) $valueObj;
+        }
+    }
+
+    /**
+     * convert xml timestamps into DateTime
+     * @param string $timestamp
+     * @return string UTC formatted datetime string
+     */
+    private static function _timestampToUTC($timestamp)
+    {
+        $tz = new DateTimeZone('UTC');
+        // strangely DateTime requires an explicit set below
+        // to show the proper time zone
+        $dateTime = new DateTime($timestamp, $tz);
+        $dateTime->setTimezone($tz);
+        return $dateTime;
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/MauticMauldinCSIBundle.php
+++ b/plugins/MauticMauldinCSIBundle/MauticMauldinCSIBundle.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle;
+
+use Mautic\PluginBundle\Bundle\PluginBundleBase;
+
+class MauticMauldinCSIBundle extends PluginBundleBase
+{
+}

--- a/plugins/MauticMauldinCSIBundle/Model/CSIModel.php
+++ b/plugins/MauticMauldinCSIBundle/Model/CSIModel.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * @package     Mauldin CSI
+ * @copyright   Copyright(c) 2017 by GGC PUBLISHING, LLC
+ * @author      Brick Abode
+ */
+
+namespace MauticPlugin\MauticMauldinCSIBundle\Model;
+
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\ListModel;
+use MauticPlugin\MauticMauldinEmailScalabilityBundle\MessageQueue\ChannelHelper;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class CSIModel
+{
+    private $channelHelper;
+    private $queue;
+    private $listModel;
+
+    public function __construct(ListModel $listModel, ChannelHelper $channelHelper)
+    {
+        $this->listModel     = $listModel;
+        $this->channelHelper = $channelHelper;
+        $this->queue         = $channelHelper->declareQueue('csi_list');
+    }
+
+    public function addToList(Lead $lead, array $addTo)
+    {
+        foreach ($addTo as $id) {
+            $message['add']['lead'] = $lead->getEmail();
+            $message['add']['list'] = substr($this->listModel->getEntity($id)->getAlias(), strlen('csi-free-'));
+            $msg                    = new AMQPMessage(serialize($message));
+            $this->queue->publish($msg);
+        }
+    }
+
+    public function removeFromList(Lead $lead, array $removeFrom)
+    {
+        foreach ($removeFrom as $id) {
+            $message['remove']['lead'] = $lead->getEmail();
+            $message['remove']['list'] = substr($this->listModel->getEntity($id)->getAlias(), strlen('csi-free-'));
+            $msg                       = new AMQPMessage(serialize($message));
+            $this->queue->publish($msg);
+        }
+    }
+}

--- a/plugins/MauticMauldinCSIBundle/Translations/en_US/messages.ini
+++ b/plugins/MauticMauldinCSIBundle/Translations/en_US/messages.ini
@@ -1,0 +1,8 @@
+mauldin.csi.campaign.event.list_optlist_action="Modify contact's CSI lists"
+mauldin.lead.lead.events.changecsilist="Modify contact's CSI lists"
+mauldin.csi.lead.events.removefromlists="Remove contact from selected CSI list(s)"
+mauldin.csi.lead.events.addtolists="Add contact to selected CSI list(s)"
+mauldin.csi.campaign.event.list_optlist_action_description="Trigger actions to modify a contact from a CSI list"
+mauldin.lead.lead.events.changecsilist_descr="Trigger actions to modify a contact from a CSI list"
+mauldin.csi.campaign.event.form.csi_list="CSI List"
+mauldin.csi.campaign.event.form.csi_list.descr="Select which CSI Lists you want to modify"


### PR DESCRIPTION
This plugin is going to be used for stuff that requires communication with CSI.

For now, it includes a new form and campaign action for adding/removing a contact from CSI lists.

The communication with CSI is done using GET requests to:

```
http://www.csi.dev/api/v2/listmanager/optIn?email=foo@bar.com&code=promo
http://www.csi.dev/api/v2/listmanager/optOut?email=foo@bar.com&code=promo
```

**NOTE** that this depends on some configuration changes, https://github.com/MauldinEconomics/csi-unicorn/pull/14.