### PR TITLE
Avoid updating replicated segments

### DIFF
--- a/plugins/MauticMauldinEmailScalabilityBundle/Command/UpdateLeadListsCommand.php
+++ b/plugins/MauticMauldinEmailScalabilityBundle/Command/UpdateLeadListsCommand.php
@@ -72,12 +72,14 @@ class UpdateLeadListsCommand extends ModeratedCommand
                 // Get first item; using reset as the key will be the ID and not 0
                 $l = reset($l);
 
-                $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
+                if (substr($l->getAlias(), 0, 4) !== 'csi-') {
+                    $output->writeln('<info>'.$translator->trans('mautic.lead.list.rebuild.rebuilding', ['%id%' => $l->getId()]).'</info>');
 
-                $processed = $listModel->rebuildListLeads($l, $batch, $max, $output);
-                $output->writeln(
-                    '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'."\n"
-                );
+                    $processed = $listModel->rebuildListLeads($l, $batch, $max, $output);
+                    $output->writeln(
+                        '<comment>'.$translator->trans('mautic.lead.list.rebuild.leads_affected', ['%leads%' => $processed]).'</comment>'."\n"
+                    );
+                }
 
                 unset($l);
             }


### PR DESCRIPTION
Skip the segments whose alias begin with `csi-` in the `mauldin:segments:update` command.