### PR TITLE
Allow tracking events from local ip

### DIFF
--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -212,7 +212,7 @@ class IpLookupHelper
         return filter_var(
             $ip,
             FILTER_VALIDATE_IP,
-            FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE
         );
     }
 


### PR DESCRIPTION
Mautic avoids tracking some events that happen from a "local" IP.

This is annoying when testing/developing, but has no impact in production.

This patch removes this annoyance.

**NOTE:** As this is very simple and has no impact in production, this branch can he kept always on top of the the ~develop~ branch for testing purposes and never merged. This seems to be somewhat an arbitrary decision.