### PR TITLE
Store sessions in the database

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -461,6 +461,15 @@ return [
             ],
         ],
         'other' => [
+            // Session handler
+            'session.handler.pdo' => [
+                'class'=> \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::class,
+                'arguments' => [
+                    '"mysql:host=mysql;port=3306;dbname=mautic"',
+                    ['db_username' => '%mautic.db_user%', 'db_password' => '%mautic.db_password%']
+                ]
+            ],
+
             // Error handler
             'mautic.core.errorhandler.subscriber' => [
                 'class'     => 'Mautic\CoreBundle\EventListener\ErrorHandlingListener',

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -463,9 +463,9 @@ return [
         'other' => [
             // Session handler
             'session.handler.pdo' => [
-                'class'=> \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::class,
+                'class' => \Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::class,
                 'arguments' => [
-                    '"mysql:host=mysql;port=3306;dbname=mautic"',
+                    '%mautic.pdo_session_string%',
                     ['db_username' => '%mautic.db_user%', 'db_password' => '%mautic.db_password%']
                 ]
             ],

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -189,7 +189,7 @@ $container->loadFromExtension('framework', [
     'trusted_hosts'   => '%mautic.trusted_hosts%',
     'trusted_proxies' => '%mautic.trusted_proxies%',
     'session'         => [ //handler_id set to null will use default session handler from php.ini
-        'handler_id' => null,
+        'handler_id' => 'session.handler.pdo',
         'name'       => $sessionName,
     ],
     'fragments'            => null,


### PR DESCRIPTION
The sessions were being stored in the `/tmp` directory, so it was local to the container.

Since a load balancer is being used, this may cause problems. Jo-Anne did report being kicked
out of the session now and then, and this might be the cause.

Depends on: https://github.com/MauldinEconomics/csi-unicorn/pull/68

Requires the creation of the sessions table:
```sql
CREATE TABLE `sessions` (
    `sess_id` VARCHAR(128) NOT NULL PRIMARY KEY,
    `sess_data` MEDIUMBLOB NOT NULL,
    `sess_time` INTEGER UNSIGNED NOT NULL,
    `sess_lifetime` MEDIUMINT NOT NULL
) COLLATE utf8_bin, ENGINE = InnoDB;

```