### PR TITLE
Fix campaign leads bug

### DIFF
--- a/plugins/MauticMauldinEmailScalabilityBundle/Model/EventModelExtended.php
+++ b/plugins/MauticMauldinEmailScalabilityBundle/Model/EventModelExtended.php
@@ -350,7 +350,7 @@ class EventModelExtended extends EventModel
                 $campaignLeads = $this->paginateLeadsStartingEvents($campaignId, $lastId, $limit);
             }
 
-            $queue->publish(implode(' ', $campaignLeads));
+            $queue->publish(serialize($campaignLeads));
 
             $lastId = array_values(array_slice($campaignLeads, -1))[0];
             $currentCount += count($campaignLeads);
@@ -444,7 +444,7 @@ class EventModelExtended extends EventModel
             $logRepo
         ) {
             try {
-                $campaignLeads = explode(' ', $msg->body);
+                $campaignLeads = unserialize($msg->body);
                 if (!empty($campaignLeads)) {
                     $leads = $this->leadModel->getEntities(
                         [


### PR DESCRIPTION
**NOTE** before deploying this fix, stop the jobs container and make sure the campaign queues are empty.

If necessary, manually flush the campaign queues.