### PR TITLE
Workaround for FoF cookie not being captured

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -939,8 +939,18 @@ class SubmissionModel extends CommonFormModel
             }
         }
 
+        // Also set lead as newly created if it had no email before.
+        // This is a workaround a problem where the form submission does not
+        // track the lead as newly created, because the lead exists (but has
+        // no email).
+        $hadNoEmail = null === $lead->getEmail();
+
         //set the mapped fields
         $this->leadModel->setFieldValues($lead, $data, false, true, true);
+
+        if ($hadNoEmail && null !== $lead->getEmail()) {
+            $lead->setNewlyCreated(true);
+        }
 
         if (!empty($event)) {
             $event->setIpAddress($ipAddress);


### PR DESCRIPTION
A lead is created with no email upon a page hit, and the subsequent form submission only updates it with the email.

So the "newly created" flag is not set on this form submission.

Since we rely on this flag to capture the FoF tracking cookies, we make this workaround.