### PR TITLE
Fix bugs and add logs to SET integration

### DIFF
--- a/plugins/MauticMauldinCSIBundle/Command/FetchSetListCommand.php
+++ b/plugins/MauticMauldinCSIBundle/Command/FetchSetListCommand.php
@@ -36,6 +36,8 @@ class FetchSetListCommand extends ModeratedCommand
 
         $listIds = $setList->getUpdatableLists();
 
+        echo('Updatable: ' . json_encode($listIds) . PHP_EOL);
+
         foreach ($listIds as $listId) {
             $flag = $setList->maybeUpdateCache($listId);
             if ($flag) {

--- a/plugins/MauticMauldinCSIBundle/Model/SETListModel.php
+++ b/plugins/MauticMauldinCSIBundle/Model/SETListModel.php
@@ -115,15 +115,13 @@ EOQ;
 
         $stmt = $this->conn->prepare($q);
         $stmt->execute();
-        $rows = $stmt->fetchAll();
+        $result = $stmt->fetchAll();
 
-        $result = [];
-        if (null !== $rows) {
-            foreach ($rows as $row) {
-                $result[] = $row['id'];
-            }
+        $listIds = [];
+        foreach ($result as $row) {
+            $listIds[] = $row['id'];
         }
-        return $result;
+        return $listIds;
     }
 
     /*

--- a/plugins/MauticMauldinEmailScalabilityBundle/Command/UpdateLeadListsCommand.php
+++ b/plugins/MauticMauldinEmailScalabilityBundle/Command/UpdateLeadListsCommand.php
@@ -186,6 +186,8 @@ class UpdateLeadListsCommand extends ModeratedCommand
      */
     protected function processSetDependencies($list)
     {
+        echo('Check SET deps for segment ' . $list->getId() . PHP_EOL);
+
         // Find SET dependencies
         $deps = [];
         foreach ($list->getFilters() as $filter) {
@@ -197,24 +199,17 @@ class UpdateLeadListsCommand extends ModeratedCommand
         if (empty($deps)) {
             return true;
         }
+        echo('  Deps: ' . json_encode($deps) . PHP_EOL);
 
         // Check if cache is valid
         $invalids = [];
         foreach ($deps as $dep) {
-            if (!$this->setListModel->isCacheValid($dep)) {
+            if (!$this->setListModel->isCacheValid($dep, $list)) {
                 $invalids[] = $dep;
+                $this->setListModel->requestCacheUpdate($dep, $list);
             }
         }
 
-        if (empty($invalids)) {
-            return true;
-        }
-
-        // Request cache update
-        foreach ($invalids as $invalid) {
-            $this->setListModel->requestCacheUpdate($invalid, $list);
-        }
-
-        return false;
+        return empty($invalids);
     }
 }


### PR DESCRIPTION
Logging:
- log the setlist row state in many places
- log the what is happening

Bugs:
- check if "timeFinished" is "truthy" instead of "not null";
- use the segment's "update_interval" when checking if cache is
      valid;
- check if there is a queued build before requesting one