### PR TITLE
Request update for unqueued lists

### DIFF
--- a/plugins/MauticMauldinCSIBundle/Model/SETRequestModel.php
+++ b/plugins/MauticMauldinCSIBundle/Model/SETRequestModel.php
@@ -167,20 +167,24 @@ class SETRequestModel
             : false;
     }
 
-    /*
+    /**
      * A newer cache is available if the time it finished bulding is more
      * recent then the time the currently used cache was built.
      *
-     * @param int $listId: The id of the SET list
-     * @param datetime $lastUpdate: the datetime when the last cache build finished
+     * @param int $listId The id of the SET list
+     * @param int $lastUpdate The timestamp when the last cache build finished
      *
-     * Returns null if a newer cache is not available;
-     * otherwise, returns the $timeFinished of the new cache.
-     * @return maybe(datetime)
+     * @return int|null
+     *    Returns the time_finished timestamp of a build cache if one exists
+     *    and is newer than $lastUpdate, null otherwise.
      */
     public function isNewerCacheAvailable($listId, $lastUpdate)
     {
-        $timeFinished = $this->getTimeFinished($listId);
+        try {
+            $timeFinished = $this->getTimeFinished($listId);
+        } catch (SETAPIException $e) {
+            $timeFinished = false;
+        }
 
         if ($timeFinished && $timeFinished > $lastUpdate) {
             return $timeFinished;


### PR DESCRIPTION
Adjusts the **SETRequestModel**'s logic for queueing builds via **requestCacheUpdate** to handle the case where no build has ever been queued for a list and **SETRequestModel::apiCall** throws a **SETAPIException** when called in **SETRequestModel::getTimeFinished**. 