### PR TITLE
Remove buggy buttons and improve segment filter

### DIFF
--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -483,6 +483,10 @@ abstract class AbstractStandardFormController extends AbstractFormController
             $model->lockEntity($entity);
         }
 
+        if ($entity instanceof \Mautic\CampaignBundle\Entity\Campaign) {
+            $form->get('buttons')->remove('apply');
+        }
+
         $delegateArgs = [
             'viewParameters' => [
                 'permissionBase'  => $this->getPermissionBase(),

--- a/app/bundles/EmailBundle/Views/Email/details.html.php
+++ b/app/bundles/EmailBundle/Views/Email/details.html.php
@@ -45,21 +45,6 @@ if (empty($emailType)) {
 
 $customButtons = [];
 if (!$isEmbedded) {
-    if ($emailType == 'list') {
-        $customButtons[] = [
-            'attr' => [
-                'data-toggle' => 'ajax',
-                'href'        => $view['router']->path(
-                    'mautic_email_action',
-                    ['objectAction' => 'send', 'objectId' => $email->getId()]
-                ),
-            ],
-            'iconClass' => 'fa fa-send-o',
-            'btnText'   => 'mautic.email.send',
-            'primary'   => true,
-        ];
-    }
-
     $customButtons[] = [
         'attr' => [
             'class'       => 'btn btn-default btn-nospin',

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -369,8 +369,11 @@ class ListModel extends FormModel
                     [
                         'include' => [
                             '=',
+                            '!=',
                             'like',
+                            '!like',
                             'regexp',
+                            '!regexp',
                         ],
                     ]
                 ),


### PR DESCRIPTION
This pull request solves the following issues:

- Add a negative version of "Visited URL" segment filter
- Remove campaign "Apply" button
- Remove email "Send" button

Each change is encapsulated on its own commit to make the refactor easier.

The segment filter improvement might be accepted by upstream.