### PR TITLE
Improved page hit error handling

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -851,14 +851,14 @@ class LeadModel extends FormModel
      *
      * @return array|Lead|null
      */
-    public function getContactFromRequest($queryFields = [], $request = null)
+    public function getContactFromRequest($queryFields = [], $request = null, $ip = null)
     {
-        if(null !== $request) {
+        if (null !== $request) {
             $this->request = $request;
         }
         $lead = null;
 
-        $ipAddress = $this->ipLookupHelper->getIpAddress();
+        $ipAddress = $this->ipLookupHelper->getIpAddress($ip);
 
         // Check for a lead requested through clickthrough query parameter
         if (isset($queryFields['ct'])) {
@@ -900,6 +900,9 @@ class LeadModel extends FormModel
         $uniqueLeadFields    = $this->leadFieldModel->getUniqueIdentiferFields();
         $uniqueLeadFieldData = [];
         $inQuery             = array_intersect_key($queryFields, $availableLeadFields);
+        if ($inQuery === null) {
+            $inQuery = [];
+        }
         foreach ($inQuery as $k => $v) {
             if (empty($queryFields[$k])) {
                 unset($inQuery[$k]);

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -50,7 +50,8 @@ class PageModel extends FormModel
     use VariantModelTrait;
     use BuilderModelTrait;
 
-    const PAGE_HIT_QUEUE = 'page-hit';
+    const PAGE_HIT_QUEUE       = 'page-hit';
+    const ERROR_PAGE_HIT_QUEUE = 'error-page-hit';
 
     protected $hitQueue = null;
 
@@ -411,12 +412,18 @@ class PageModel extends FormModel
         return implode('/', $slugs);
     }
 
-    public function getPageHitQueue()
+    public function getPageHitQueue($queueName = self::PAGE_HIT_QUEUE)
     {
         if ($this->hitQueue === null) {
-            $this->hitQueue = $this->getChannelHelper()->declareQueue(self::PAGE_HIT_QUEUE);
+            $this->hitQueue = $this->getChannelHelper()->declareQueue($queueName);
         }
+
         return $this->hitQueue;
+    }
+
+    public function getErrorPageHitQueue()
+    {
+        return $this->getChannelHelper()->declareQueue(self::ERROR_PAGE_HIT_QUEUE);
     }
 
     public function queueHitPage($page, Request $request, $code = '200', Lead $lead = null, $query = [])
@@ -426,15 +433,15 @@ class PageModel extends FormModel
             return;
         }
 
-        $queue = $this->getPageHitQueue();
+        $queue     = $this->getPageHitQueue();
         $ipAddress = $this->ipLookupHelper->getIpAddress();
-        $ip = $ipAddress->getIpAddress();
-        $leadId = null;
+        $ip        = $ipAddress->getIpAddress();
+        $leadId    = null;
         // Get lead if required
         if (null == $lead) {
-            $lead = $this->leadModel->getContactFromRequest($query);
+            $lead = $this->leadModel->getContactFromRequest($query === null ? [] : $query);
         }
-        if(null !== $lead) {
+        if (null !== $lead) {
             $leadIpAddresses = $lead->getIpAddresses();
             if (!$leadIpAddresses->contains($ipAddress)) {
                 $lead->addIpAddress($ipAddress);
@@ -447,9 +454,9 @@ class PageModel extends FormModel
             $pageId = $page->getId();
         }
         $pageType = null;
-        if($page instanceof Redirect) {
+        if ($page instanceof Redirect) {
             $pageType = 'redirect';
-        } else if ($page instanceof Page) {
+        } elseif ($page instanceof Page) {
             $pageType = 'page';
         }
 
@@ -460,27 +467,30 @@ class PageModel extends FormModel
             'code'     => $code,
             'leadId'   => $leadId,
             'query'    => $query,
-            'ip'       => $ip
+            'ip'       => $ip,
         ]));
     }
 
     public function consumeHitPage($pageId, $pageType, Request $request, $code = '200', $leadId = null, $query = [], $ip = null)
     {
-        $lead = null;
-        if(null !== $leadId) {
-            $lead = $this->leadModel->getEntity($leadId);
-            if($lead === null){
-                $lead = $this->leadModel->getContactFromRequest($query === null ?  [] : $query,$request);
+        $this->em->transactional(function () use ($pageId, $pageType, $request, $code, $leadId, $query, $ip) {
+            $lead = null;
+            if (null !== $leadId) {
+                $lead = $this->leadModel->getEntity($leadId);
+                if ($lead === null) {
+                    $lead = $this->leadModel->getContactFromRequest($query === null ? [] : $query, $request, $ip);
+                } else {
+                    $this->leadModel->setCurrentLead($lead);
+                }
             }
-            $this->leadModel->setCurrentLead($lead);
-        }
-        $page = null;
-        if($pageType === 'redirect') {
-            $page = $this->pageRedirectModel->getEntity($pageId);
-        } else if($pageType === 'page')  {
-            $page = $this->getEntity($pageId);
-        }
-        $this->hitPage($page, $request, $code, $lead, $query, $ip);
+            $page = null;
+            if ($pageType === 'redirect') {
+                $page = $this->pageRedirectModel->getEntity($pageId);
+            } elseif ($pageType === 'page') {
+                $page = $this->getEntity($pageId);
+            }
+            $this->hitPage($page, $request, $code, $lead, $query, $ip);
+        });
     }
 
     /**

--- a/plugins/MauticMauldinEmailScalabilityBundle/Command/ProcessPageHitCommand.php
+++ b/plugins/MauticMauldinEmailScalabilityBundle/Command/ProcessPageHitCommand.php
@@ -8,9 +8,11 @@
 
 namespace MauticPlugin\MauticMauldinEmailScalabilityBundle\Command;
 
+use Mautic\PageBundle\Model\PageModel;
 use MauticPlugin\MauticMauldinEmailScalabilityBundle\MessageQueue\QueueProcessingCommand;
 use MauticPlugin\MauticMauldinEmailScalabilityBundle\MessageQueue\QueueRequestHelper;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -25,7 +27,8 @@ class ProcessPageHitCommand extends QueueProcessingCommand
     {
         $this
             ->setName('mauldin:page:hits')
-            ->setDescription('Processes page hit queue');
+            ->setDescription('Processes page hit queue')
+            ->addOption('--process-errors', null, InputOption::VALUE_NONE, 'Process hits from the error queue');
 
         parent::configure();
     }
@@ -35,25 +38,37 @@ class ProcessPageHitCommand extends QueueProcessingCommand
      */
     protected function setup(InputInterface $input, OutputInterface $output)
     {
-        $container  = $this->getContainer();
-        $pageModel  = $container->get('mautic.page.model.page');
-        $queue      = $pageModel->getPageHitQueue();
-
+        $container     = $this->getContainer();
+        $pageModel     = $container->get('mautic.page.model.page');
+        $processErrors = $input->getOption('process-errors');
+        $errorQueue    = $pageModel->getErrorPageHitQueue();
+        if ($processErrors) {
+            $queue = $pageModel->getPageHitQueue(PageModel::ERROR_PAGE_HIT_QUEUE);
+        } else {
+            $queue = $pageModel->getPageHitQueue();
+        }
         $this->channel = $queue->getChannel();
 
-        $callback = function ($msg) use ($pageModel) {
-            $message = unserialize($msg->body);
-            $pageModel->consumeHitPage(
-                $message['pageId'],
-                $message['pageType'],
-                QueueRequestHelper::buildRequest($message['request']),
-                $message['code'],
-                $message['leadId'],
-                $message['query'],
-                $message['ip']
-            );
-
-            $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+        $callback = function ($msg) use ($pageModel, $errorQueue, $processErrors) {
+            try {
+                $message = unserialize($msg->body);
+                $pageModel->consumeHitPage(
+                    $message['pageId'],
+                    $message['pageType'],
+                    QueueRequestHelper::buildRequest($message['request']),
+                    $message['code'],
+                    $message['leadId'],
+                    $message['query'],
+                    $message['ip']
+                );
+                $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+            } catch (\Exception $e) {
+                error_log($e->getMessage());
+                if (!$processErrors) {
+                    $errorQueue->publish($msg);
+                    $msg->delivery_info['channel']->basic_ack($msg->delivery_info['delivery_tag']);
+                }
+            }
         };
 
         $queue->consume($callback);


### PR DESCRIPTION
The last page hit fix does not seem to have solved the problem, even though the particular exception that Max reported was reproduced here and fixed.

So we decided to handle the page hit errors by removing the problematic message from the normal queue and adding it to a separate queue. This is intended to stop the pilling up of messages in the queue, which already passes 300k.

We expect the messages in the queue to be mostly consumed after this patch, and the problematic messages to be isolated in the error queue so we can debug.

The messages in the error queue can be consumed by running the job manually with the command line option `--process-errors`.