### PR TITLE
Fix negative options of visited url segment filter

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -879,6 +879,7 @@ class LeadListRepository extends CommonRepository
                             break;
                         case 'like':
                         case '!like':
+                        case 'notLike':
                             $details['filter'] = '%'.$details['filter'].'%';
                             $subqb->where(
                                 $q->expr()->andX(

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -373,7 +373,6 @@ class ListModel extends FormModel
                             'like',
                             '!like',
                             'regexp',
-                            '!regexp',
                         ],
                     ]
                 ),


### PR DESCRIPTION
I've removed the `!regex` because it is broken and I don't suppose it will be used (it was added by us).