### PR TITLE
Limit number of Stat 'openDetails'

### DIFF
--- a/app/bundles/EmailBundle/Entity/Stat.php
+++ b/app/bundles/EmailBundle/Entity/Stat.php
@@ -22,6 +22,9 @@ use Mautic\LeadBundle\Entity\Lead;
  */
 class Stat
 {
+    /** @var int Limit number of stored 'openDetails' */
+    const MAX_OPEN_DETAILS = 1000;
+
     /**
      * @var int
      */
@@ -542,7 +545,9 @@ class Stat
      */
     public function addOpenDetails($details)
     {
-        $this->openDetails[] = $details;
+        if (self::MAX_OPEN_DETAILS > $this->getOpenCount()) {
+            $this->openDetails[] = $details;
+        }
 
         ++$this->openCount;
     }


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

#### Description:

When calling **Stat#addOpenDetails()**, the argument will only be added to the _openDetails_ array if the "openCount" is less than `Stat::MAX_OPEN_DETAILS` (1,000). The "openCount" will be incremented regardless.

## CAVEAT

This has not been tested, nor is there a test for it. There probably could/should be a scenario added to our external test suite.