### PR TITLE
Bugfix/optin missing email

### DIFF
--- a/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
@@ -81,7 +81,13 @@ class FormSubscriber extends CommonSubscriber
     public function onChangeLists(SubmissionEvent $event)
     {
         /** @var \Mautic\LeadBundle\Model\Lead $lead */
-        $lead = $event->getLead();
+        $lead      = $event->getLead();
+        $leadEmail = $lead->getEmail();
+
+        // Short-circuit if the lead doesn't have an email address.
+        if (empty($leadEmail)) {
+            return;
+        }
 
         $properties = $event->getActionConfig();
         $addTo      = $properties['addToLists'];

--- a/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticMauldinCSIBundle/EventListener/FormSubscriber.php
@@ -76,27 +76,23 @@ class FormSubscriber extends CommonSubscriber
      * Callback: queue the action for adding or removing from a CSI list.
      * Also handles FoF.
      *
-     * @param $action
-     * @param $factory
+     * @param SubmissionEvent $event
      */
     public function onChangeLists(SubmissionEvent $event)
     {
-        $properties = $event->getActionConfig();
-
         /** @var \Mautic\LeadBundle\Model\Lead $lead */
-        $lead       = $event->getLead();
+        $lead = $event->getLead();
+
+        $properties = $event->getActionConfig();
         $addTo      = $properties['addToLists'];
         $removeFrom = $properties['removeFromLists'];
 
         if (!empty($addTo)) {
-            /*
-             * Gets the FoF cookie. This is required because the other callback
-             * is always executed after this one, so the new lead does not have
-             * the FoF cookies set yet.
-             */
-            if ($lead->isNewlyCreated())
-            {
-                $this->setLeadFoFCookievalues($lead, $event->getRequest()->cookies);
+            // Gets the FoF cookie. This is required because the other callback
+            // is always executed after this one, so the new lead does not have
+            // the FoF cookies set yet.
+            if ($lead->isNewlyCreated()) {
+                $this->setLeadFoFCookieValues($lead, $event->getRequest()->cookies);
             }
 
             $this->csiListModel->addToList($lead, $addTo);
@@ -113,16 +109,17 @@ class FormSubscriber extends CommonSubscriber
      *
      * This is required so that any form submission which creates a lead
      * also set its FoF cookies.
+     *
+     * @param SubmissionEvent $event
      */
     public function onFormSubmit(SubmissionEvent $event)
     {
         /** @var \Mautic\LeadBundle\Entity\Lead $lead */
         $lead = $event->getLead();
-        if ($lead->isNewlyCreated())
-        {
+
+        if ($lead->isNewlyCreated()) {
             $this->setLeadFoFCookieValues($lead, $event->getRequest()->cookies);
         }
-
     }
 
     /**
@@ -130,7 +127,7 @@ class FormSubscriber extends CommonSubscriber
      * exist. Should only be used if the Lead 'is newly created.
      *
      * @param Lead $lead
-     * @param      $cookies
+     * @param \Symfony\Component\HttpFoundation\ParameterBag $cookies
      */
     private function setLeadFoFCookieValues(Lead $lead, $cookies)
     {

--- a/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * @package   Mautic CSI Bundle
+ * @copyright Copyright(c) 2018 by GGC Publishing, LLC
+ * @author    Max Lawton <max@mauldineconomics.com>
+ */
+
+namespace MauticPlugin\MauticMauldinCsiBundle\Tests\EventListener;
+
+use MauticPlugin\MauticMauldinCsiBundle\EventListener\FormSubscriber;
+use Mautic\LeadBundle\Entity\Lead;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use MauticPlugin\MauticMauldinCsiBundle\CSIEvents;
+use MauticPlugin\MauticMauldinCsiBundle\Model\CSIListModel;
+
+
+/**
+ * Form Subscriber Test.
+ */
+class FormSubscriberTest extends KernelTestCase
+{
+    /** @var array */
+    protected $leads;
+
+    /** @var LeadModel */
+    protected $leadModel;
+
+    /** @var CSIListModel */
+    protected $csiListModel;
+
+    /** @var EventDispatcher */
+    protected $dispatcher;
+
+    /** @var FormSubscriber */
+    protected $formSubscriber;
+
+    /**
+     * Set up.
+     */
+    public function setUp()
+    {
+        $this->leads          = [];
+        $this->leadModel      = $this->createMock(LeadModel::class);
+        $this->csiListModel   = $this->getMockCsiListModel();
+        $this->dispatcher     = new EventDispatcher();
+        $this->formSubscriber = new FormSubscriber($this->leadModel, $this->csiListModel);
+        $this->dispatcher->addSubscriber($formSubscriber);
+    }
+
+    /**
+     * Test that a lead with an email address does opt in.
+     */
+    public function testLeadWithEmailDoesOptIn()
+    {
+        $lead  = $this->getLeadWithEmail();
+        $event = $this->getSubmissionEvent($lead);
+
+        $this->dispatchEvent($event);
+        $this->assertTrue($this->hasLeadInList($lead));
+    }
+
+    /**
+     * Test that a lead without an email address does not opt in.
+     */
+    public function testLeadWithoutEmailDoesNotOptIn()
+    {
+        $lead  = $this->getLeadWithoutEmail();
+        $event = $this->getSubmissionEvent($lead);
+
+        $this->dispatchEvent($event);
+        $this->assertFalse($this->hasLeadInList($lead));
+    }
+
+    /**
+     * Get lead with email.
+     *
+     * @return Lead
+     */
+    public function getLeadWithEmail()
+    {
+        $lead = $this->createMock(Lead::class);
+        $lead->expects($this->any())
+            ->method('getEmail')
+            ->willReturn('test@example.com');
+
+        return $lead;
+    }
+
+    /**
+     * Get lead without email.
+     *
+     * @return Lead
+     */
+    public function getLeadWithoutEmail()
+    {
+        $lead = $this->createMock(Lead::class);
+        $lead->expects($this->any())
+            ->method('getEmail')
+            ->willReturn(null);
+
+        return $lead;
+    }
+
+    /**
+     * Get submission event.
+     *
+     * @param Lead $lead
+     * @return SubmissionEvent
+     */
+    public function getSubmissionEvent(Lead $lead)
+    {
+        $event = $this->createMock(SubmissionEvent::class);
+
+        $event->expects($this->any())
+            ->method('getLead')
+            ->willReturn($lead);
+
+        $event->expects($this->any())
+            ->method('getActionConfig')
+            ->willReturn([
+                'addToLists'      => ['list'],
+                'removeFromLists' => [],
+            ]);
+
+        return $event;
+    }
+
+    /**
+     * Add lead to list.
+     *
+     * @param Lead $lead
+     * @param array $addTo
+     */
+    public function addLeadToList(Lead $lead, array $addTo)
+    {
+        $this->leads[] = $lead;
+    }
+
+    /**
+     * Has lead in list.
+     *
+     * @param Lead $lead
+     * @return bool
+     */
+    public function hasLeadInList(Lead $lead)
+    {
+        return in_array($lead, $this->leads);
+    }
+
+    /**
+     * Get mock CSIListModel.
+     *
+     * @return CSIListModel
+     */
+    protected function getMockCsiListModel()
+    {
+        $csiList = $this->createMock(CSIListModel::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $csiList->expects($this->any())
+            ->method('addToList')
+            ->will($this->returnCallback([$this, 'addLeadToList']));
+
+        return $csiList;
+    }
+
+}

--- a/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
@@ -26,29 +26,22 @@ class FormSubscriberTest extends KernelTestCase
     /** @var array */
     protected $leads;
 
-    /** @var LeadModel */
-    protected $leadModel;
-
-    /** @var CSIListModel */
-    protected $csiListModel;
-
     /** @var EventDispatcher */
     protected $dispatcher;
-
-    /** @var FormSubscriber */
-    protected $formSubscriber;
 
     /**
      * Set up.
      */
     public function setUp()
     {
-        $this->leads          = [];
-        $this->leadModel      = $this->createMock(LeadModel::class);
-        $this->csiListModel   = $this->getMockCsiListModel();
-        $this->dispatcher     = new EventDispatcher();
-        $this->formSubscriber = new FormSubscriber($this->leadModel, $this->csiListModel);
-        $this->dispatcher->addSubscriber($formSubscriber);
+        $this->leads      = [];
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber(
+            new FormSubscriber(
+                $this->createMock(LeadModel::class),
+                $this->getMockCsiListModel()
+            )
+        );
     }
 
     /**

--- a/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/plugins/MauticMauldinCSIBundle/Tests/EventListener/FormSubscriberTest.php
@@ -8,12 +8,14 @@
 
 namespace MauticPlugin\MauticMauldinCsiBundle\Tests\EventListener;
 
+use MauticPlugin\MauticMauldinCsiBundle\CSIEvents;
 use MauticPlugin\MauticMauldinCsiBundle\EventListener\FormSubscriber;
+use MauticPlugin\MauticMauldinCsiBundle\Model\CSIListModel;
+use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
-use MauticPlugin\MauticMauldinCsiBundle\CSIEvents;
-use MauticPlugin\MauticMauldinCsiBundle\Model\CSIListModel;
 
 
 /**
@@ -156,15 +158,23 @@ class FormSubscriberTest extends KernelTestCase
      */
     protected function getMockCsiListModel()
     {
-        $csiList = $this->createMock(CSIListModel::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $csiList = $this->createMock(CSIListModel::class);
 
         $csiList->expects($this->any())
             ->method('addToList')
             ->will($this->returnCallback([$this, 'addLeadToList']));
 
         return $csiList;
+    }
+
+    /**
+     * Dispatch event.
+     *
+     * @param SubmissionEvent $event
+     */
+    protected function dispatchEvent(SubmissionEvent $event)
+    {
+        $this->dispatcher->dispatch(CSIEvents::ON_MODIFY_CSI_LIST, $event);
     }
 
 }


### PR DESCRIPTION
Prevent leads without email address from being pushed to CSI lists.

**N.B.** This updates code within one of our plugins, also tracked in its own repo. There is an identical PR in the plugin repo. This one is in case we determine we need this update immediately.