### PR TITLE
HACK to fix redirect loop behind AWS ELBv2

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,6 +13,12 @@ define('MAUTIC_ROOT_DIR', __DIR__);
 // Fix for hosts that do not have date.timezone set, it will be reset based on users settings
 date_default_timezone_set('UTC');
 
+// HACK to fix redirect loop behind AWS ELBv2
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+    $_SERVER['HTTPS'] = 'on';
+    $_SERVER['SERVER_PORT'] = 443;
+}
+
 use Mautic\Middleware\MiddlewareBuilder;
 use Symfony\Component\ClassLoader\ApcClassLoader;
 


### PR DESCRIPTION
Tricks Mautic into thinking it is running with HTTPS on port 443 when the _X-Forwarded-Proto_ header contains `'https'`.