### PR TITLE
SendGrid Categories support in Prod

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -472,6 +472,12 @@ return [
             'mautic.transport.sendgrid_api.mail.attachment' => [
                 'class' => \Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment::class,
             ],
+            'mautic.transport.sendgrid_api.mail.categories' => [
+                'class' => \Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailCategories::class,
+                'arguments' => [
+                    'event_dispatcher',
+                ],
+            ],
             'mautic.transport.sendgrid_api.message' => [
                 'class'     => \Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage::class,
                 'arguments' => [
@@ -479,6 +485,7 @@ return [
                     'mautic.transport.sendgrid_api.mail.personalization',
                     'mautic.transport.sendgrid_api.mail.metadata',
                     'mautic.transport.sendgrid_api.mail.attachment',
+                    'mautic.transport.sendgrid_api.mail.categories',
                 ],
             ],
             'mautic.transport.sendgrid_api.response' => [

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/SendGridMailCategoriesEvent.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/SendGridMailCategoriesEvent.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid\Event;
+
+use ArrayObject;
+use SendGrid\Mail;
+use Swift_Mime_Message;
+use Symfony\Component\EventDispatcher\Event;
+
+class SendGridMailCategoriesEvent extends Event
+{
+    /** @var Mail */
+    private $mail;
+
+    /** @var Swift_Mime_Message */
+    private $message;
+
+    /** @var ArrayObject */
+    private $categories;
+
+    /**
+     * Constructor.
+     *
+     * @param Mail $mail
+     * @param Swift_Mime_Message $message
+     */
+    public function __construct(Mail $mail, Swift_Mime_Message $message)
+    {
+        $this->mail       = $mail;
+        $this->message    = $message;
+        $this->categories = new ArrayObject();
+    }
+
+    /**
+     * Get mail.
+     *
+     * @return Mail
+     */
+    public function getMail()
+    {
+        return $this->mail;
+    }
+
+    /**
+     * Get message.
+     *
+     * @return Swift_Mime_Message
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * Get categories.
+     *
+     * @return ArrayObject
+     */
+    public function getCategories()
+    {
+        return $this->categories;
+    }
+
+    /**
+     * Add category.
+     *
+     * @param string $category
+     *
+     * @return $this
+     */
+    public function addCategory($category)
+    {
+        $this->categories->append($category);
+
+        return $this;
+    }
+}

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailCategories.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Mail/SendGridMailCategories.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid\Mail;
+
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\SendGridMailCategoriesEvent;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
+use SendGrid\Mail;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class SendGridMailCategories
+{
+    /** @var EventDispatcher */
+    private $dispatcher;
+
+    /**
+     * Constructor.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * @param Mail                $mail
+     * @param \Swift_Mime_Message $message
+     */
+    public function addCategoriesToMail(Mail $mail, \Swift_Mime_Message $message)
+    {
+        if (!$message instanceof MauticMessage) {
+            return;
+        }
+
+        $event = new SendGridMailCategoriesEvent($mail, $message);
+
+        $this->dispatcher->dispatch(SendGridMailEvents::ADD_CATEGORIES, $event);
+
+        foreach ($event->getCategories() as $category) {
+            $mail->addCategory($category);
+        }
+    }
+}

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
@@ -13,6 +13,7 @@ namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
 
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailCategories;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use SendGrid\Mail;
@@ -39,16 +40,23 @@ class SendGridApiMessage
      */
     private $sendGridMailAttachment;
 
+    /**
+     * @var SendGridMailCategories
+     */
+    private $sendGridMailCategories;
+
     public function __construct(
         SendGridMailBase $sendGridMailBase,
         SendGridMailPersonalization $sendGridMailPersonalization,
         SendGridMailMetadata $sendGridMailMetadata,
-        SendGridMailAttachment $sendGridMailAttachment
+        SendGridMailAttachment $sendGridMailAttachment,
+        SendGridMailCategories $sendGridMailCategories
     ) {
         $this->sendGridMailBase            = $sendGridMailBase;
         $this->sendGridMailPersonalization = $sendGridMailPersonalization;
         $this->sendGridMailMetadata        = $sendGridMailMetadata;
         $this->sendGridMailAttachment      = $sendGridMailAttachment;
+        $this->sendGridMailCategories      = $sendGridMailCategories;
     }
 
     /**
@@ -63,6 +71,7 @@ class SendGridApiMessage
         $this->sendGridMailPersonalization->addPersonalizedDataToMail($mail, $message);
         $this->sendGridMailMetadata->addMetadataToMail($mail, $message);
         $this->sendGridMailAttachment->addAttachmentsToMail($mail, $message);
+        $this->sendGridMailCategories->addCategoriesToMail($mail, $message);
 
         return $mail;
     }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
+
+final class SendGridMailEvents
+{
+    /**
+     * The mautic.email.swiftmailer.sendgrid_api.add_categories event is
+     * dispatched by the mautic.transport.sendgrid_api.mail.categories service
+     * when its addCategoriesToMail method is called by the SendGridApiMessage
+     * class as the last step before returning a SendGrid\Mail instance in the
+     * getMessage method.
+     *
+     * The event listener receives an instance of
+     * Mautic\EmailBundle\Swiftmailer\SendGrid\Event\SendGridMailCategoriesEvent.
+     *
+     * @var string
+     */
+    const ADD_CATEGORIES = 'mautic.email.swiftmailer.sendgrid_api.add_categories';
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailCategoriesTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Mail/SendGridMailCategoriesTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Mail;
+
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\SendGridMailCategoriesEvent;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailCategories;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
+use SendGrid\Mail;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SendGridMailCategoriesTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testNotMauticMessage()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = new TestCategoriesSubscriber();
+        $dispatcher->addSubscriber($subscriber);
+
+        $sendGridMailCategories = new SendGridMailCategories($dispatcher);
+
+        $message = $this->getMockBuilder(\Swift_Mime_Message::class)
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail->expects($this->never())
+            ->method('addCategory');
+
+        $sendGridMailCategories->addCategoriesToMail($mail, $message);
+    }
+
+    public function testNoCategories()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = new TestCategoriesSubscriber(); // no args = no category
+        $dispatcher->addSubscriber($subscriber);
+
+        $sendGridMailCategories = new SendGridMailCategories($dispatcher);
+
+        $message = $this->getMockBuilder(MauticMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail->expects($this->never())
+            ->method('addCategory');
+
+        $sendGridMailCategories->addCategoriesToMail($mail, $message);
+    }
+
+    public function testCategories()
+    {
+        $dispatcher  = new EventDispatcher();
+        $subscriber1 = new TestCategoriesSubscriber('foo');
+        $subscriber2 = new TestCategoriesSubscriber('bar');
+        $dispatcher->addSubscriber($subscriber1);
+        $dispatcher->addSubscriber($subscriber2);
+
+        $sendGridMailCategories = new SendGridMailCategories($dispatcher);
+
+        $message = $this->getMockBuilder(MauticMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->setMethodsExcept(['addCategory', 'getCategories'])
+            ->getMock();
+
+        $sendGridMailCategories->addCategoriesToMail($mail, $message);
+
+        $categories = $mail->getCategories();
+
+        $this->assertContains('foo', $categories);
+        $this->assertContains('bar', $categories);
+    }
+}
+
+/**
+ * Test subscriber to add a Category to the event if so instantiated.
+ */
+class TestCategoriesSubscriber implements EventSubscriberInterface
+{
+    /** @var string|null */
+    protected $category = null;
+
+    /**
+     * Get subscribed events.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            SendGridMailEvents::ADD_CATEGORIES => ['onAddCategories', 0],
+        ];
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param string|null $category
+     */
+    public function __construct($category = null)
+    {
+        $this->category = $category;
+    }
+
+    /*
+     * @param SendGridMailCategoriesEvent $event
+     */
+    public function onAddCategories(SendGridMailCategoriesEvent $event)
+    {
+        if ($this->category) {
+            $event->addCategory($this->category);
+        }
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
@@ -13,6 +13,7 @@ namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid;
 
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailCategories;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
@@ -38,6 +39,10 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $sendGridMailCategories = $this->getMockBuilder(SendGridMailCategories::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $mail = $this->getMockBuilder(Mail::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -46,7 +51,7 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment);
+        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment, $sendGridMailCategories);
 
         $sendGridMailBase->expects($this->once())
             ->method('getSendGridMail')
@@ -63,6 +68,10 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
 
         $sendGridMailAttachment->expects($this->once())
             ->method('addAttachmentsToMail')
+            ->with($mail, $message);
+
+        $sendGridMailCategories->expects($this->once())
+            ->method('addCategoriesToMail')
             ->with($mail, $message);
 
         $result = $sendGridApiMessage->getMessage($message);


### PR DESCRIPTION
This PR is just to confirm that the recently submitted `feature/sendgrid-mail-categories` work is ready to go into our **prod** deployment.