### PR TITLE
Bugfix/reject non hits (internal)

### DIFF
--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -186,6 +186,7 @@ class PageSubscriber extends CommonSubscriber
         $payload                = $event->getPayload();
         $request                = $payload['request'];
         $trackingNewlyGenerated = $payload['isNew'];
+        $hitId                  = $payload['hitId'];
         $pageId                 = $payload['pageId'];
         $leadId                 = $payload['leadId'];
         $isRedirect             = $payload['isRedirect'];
@@ -193,8 +194,16 @@ class PageSubscriber extends CommonSubscriber
         $pageRepo               = $this->em->getRepository('MauticPageBundle:Page');
         $redirectRepo           = $this->em->getRepository('MauticPageBundle:Redirect');
         $leadRepo               = $this->em->getRepository('MauticLeadBundle:Lead');
-        $hit                    = $hitRepo->find((int) $payload['hitId']);
+        $hit                    = $hitId ? $hitRepo->find((int) $hitId) : null;
         $lead                   = $leadId ? $leadRepo->find((int) $leadId) : null;
+
+        // On the off chance that the queue contains a message which does not
+        // reference a valid Hit, discard it to avoid clogging the queue.
+        if (null === $hit) {
+            $event->setResult(QueueConsumerResults::REJECT);
+
+            return;
+        }
 
         if ($isRedirect) {
             $page = $pageId ? $redirectRepo->find((int) $pageId) : null;

--- a/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
@@ -11,9 +11,23 @@
 
 namespace Mautic\PageBundle\Tests\EventListener;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+use Mautic\CoreBundle\Helper\IpLookupHelper;
+use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Templating\Helper\AssetsHelper;
 use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Event\PageBuilderEvent;
+use Mautic\PageBundle\EventListener\PageSubscriber;
+use Mautic\PageBundle\Model\PageModel;
+use Mautic\QueueBundle\Event\QueueConsumerEvent;
+use Mautic\QueueBundle\Queue\QueueConsumerResults;
+use Mautic\QueueBundle\QueueEvents;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
 
 class PageSubscriberTest extends WebTestCase
 {
@@ -27,5 +41,109 @@ class PageSubscriberTest extends WebTestCase
         $tokens = $pageBuilderEvent->getTokens();
         $this->assertArrayHasKey('{token_test}', $tokens);
         $this->assertEquals($tokens['{token_test}'], 'TOKEN VALUE');
+    }
+
+    public function testOnPageHit_WhenCalled_AcknowledgesHit()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = $this->getPageSubscriber();
+
+        $dispatcher->addSubscriber($subscriber);
+
+        $payload = $this->getNonEmptyPayload();
+        $event   = new QueueConsumerEvent($payload);
+
+        $dispatcher->dispatch(QueueEvents::PAGE_HIT, $event);
+
+        $this->assertEquals($event->getResult(), QueueConsumerResults::ACKNOWLEDGE);
+    }
+
+    public function testOnPageHit_WhenCalled_RejectsBadHit()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = $this->getPageSubscriber();
+
+        $dispatcher->addSubscriber($subscriber);
+
+        $payload = $this->getEmptyPayload();
+        $event   = new QueueConsumerEvent($payload);
+
+        $dispatcher->dispatch(QueueEvents::PAGE_HIT, $event);
+
+        $this->assertEquals($event->getResult(), QueueConsumerResults::REJECT);
+    }
+
+    /**
+     * Get page subscriber with mocked dependencies.
+     *
+     * @return PageSubscriber
+     */
+    protected function getPageSubscriber()
+    {
+        $assetsHelperMock   = $this->createMock(AssetsHelper::class);
+        $ipLookupHelperMock = $this->createMock(IpLookupHelper::class);
+        $auditLogModelMock  = $this->createMock(AuditLogModel::class);
+        $pageModelMock      = $this->createMock(PageModel::class);
+        $entityManagerMock  = $this->createMock(EntityManager::class);
+        $hitRepository      = $this->createMock(EntityRepository::class);
+        $pageRepository     = $this->createMock(EntityRepository::class);
+        $leadRepository     = $this->createMock(EntityRepository::class);
+        $hitMock            = $this->createMock(Hit::class);
+        $leadMock           = $this->createMock(Lead::class);
+
+        $hitRepository->expects($this->any())
+            ->method('find')
+            ->will($this->returnValue($hitMock));
+
+        $leadRepository->expects($this->any())
+            ->method('find')
+            ->will($this->returnValue($leadMock));
+
+        $entityManagerMock->expects($this->any())
+            ->method('getRepository')
+            ->will($this->returnValueMap([
+                ['MauticPageBundle:Hit', $hitRepository],
+                ['MauticPageBundle:Page', $pageRepository],
+                ['MauticLeadBundle:Lead', $leadRepository],
+            ]));
+
+        $pageSubscriber = new PageSubscriber(
+            $assetsHelperMock,
+            $ipLookupHelperMock,
+            $auditLogModelMock,
+            $pageModelMock
+        );
+
+        $pageSubscriber->setEntityManager($entityManagerMock);
+
+        return $pageSubscriber;
+    }
+
+    /**
+     * Get non empty payload, having a Request and non-null entity IDs.
+     *
+     * @return array
+     */
+    protected function getNonEmptyPayload()
+    {
+        $requestMock = $this->createMock(Request::class);
+
+        return [
+            'request' => $requestMock,
+            'isNew'   => true,
+            'hitId'   => 123,
+            'pageId'  => 456,
+            'leadId'  => 789,
+        ];
+    }
+
+    /**
+     * Get empty payload with all null entity IDs.
+     *
+     * @return array
+     */
+    protected function getEmptyPayload()
+    {
+        return array_fill_keys(['request', 'isNew', 'hitId', 'pageId', 'leadId'], null);
     }
 }

--- a/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
@@ -129,11 +129,12 @@ class PageSubscriberTest extends WebTestCase
         $requestMock = $this->createMock(Request::class);
 
         return [
-            'request' => $requestMock,
-            'isNew'   => true,
-            'hitId'   => 123,
-            'pageId'  => 456,
-            'leadId'  => 789,
+            'request'    => $requestMock,
+            'isNew'      => true,
+            'hitId'      => 123,
+            'pageId'     => 456,
+            'leadId'     => 789,
+            'isRedirect' => false,
         ];
     }
 
@@ -144,6 +145,6 @@ class PageSubscriberTest extends WebTestCase
      */
     protected function getEmptyPayload()
     {
-        return array_fill_keys(['request', 'isNew', 'hitId', 'pageId', 'leadId'], null);
+        return array_fill_keys(['request', 'isNew', 'hitId', 'pageId', 'leadId', 'isRedirect'], null);
     }
 }


### PR DESCRIPTION
Internal PR
===========

This PR is specific to the **MauldinEconomics/mautic** fork. It is a version of the _bugfix/reject-non-hits_ branch and rebased onto the _staging-submitted_ branch. There is an additional commit which allows the unit tests to work with changes that are in _staging-submitted_ but have not been accepted into _staging_.

Original PR
===========

| Q  | A
| --- | ---
| Bug fix? | Y
| New feature? | N
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | N
| Deprecations? | N


#### Description:

If a message makes it on to the `page_hit` queue without a valid `hitId`, an exception will be thrown when **PageSubscriber::onPageHit()** calls the **PageModel::processPageHit()** method. This causes the `mautic:queue:process` command to exit prematurely and the message will remain on the queue.

In order to avoid attempts to process bad messages, this PR introduces a condition which will mark a `page_hit` queue message as _REJECTED_ when there is no **Hit** to be found.

##### Caveat:

This PR does not provide any mechanism for retaining the _rejected_ queue messages. Though they are largely useless to Mautic, some users may wish to retain those unprocessed messages elsewhere. This can be done by subscribing to `QueueEvents::PAGE_HIT`, _after_ the **PageSubscriber** has marked the message to be rejected.

#### Steps to reproduce the bug:
1. Somehow get a message onto the `page_hit` queue which contains a `hitId` value for which there is no **Hit** entity (e.g. `null`).
2. Run the `mautic:queue:process` command with `--queue-name=page_hit`.
3. An exception is thrown, the bad message is still first in line on the queue.

#### Steps to test this PR:
1. Run the included unit tests:
   ```
   $ bin/phpunit --bootstrap vendor/autoload.php \
        --configuration app/phpunit.xml.dist \
        --filter PageSubscriberTest
   ```
2. With a similarly bad (or the same) message as queued in the previous section, process the `page_hit` queue:
   ```
   $ php app/console mautic:queue:process --queue-name=page_hit
   ```
