### PR TITLE
Staging.frequency rule improvments

### DIFF
--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -157,6 +157,10 @@ class FrequencyRuleRepository extends CommonRepository
                 ->setParameter('channel', $channel);
         }
 
+        // Preferred channel is stored in this table so they may not have a frequency rule defined but just a preference so exclude them
+        $q->andWhere('fr.frequency_time IS NOT NULL AND fr.frequency_number IS NOT NULL');
+
+        // Calculate the rule timeframe
         $q->andWhere(
             '(ch.'.$statSentColumn.' >= case fr.frequency_time
                  when \'MONTH\' then DATE_SUB(NOW(),INTERVAL 1 MONTH)
@@ -226,7 +230,8 @@ class FrequencyRuleRepository extends CommonRepository
         $subQuery = $this->getEntityManager()->getConnection()->createQueryBuilder();
         $subQuery->select('null')
             ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr')
-            ->where("fr.lead_id = ch.{$statContactColumn}");
+            ->where("fr.lead_id = ch.{$statContactColumn}")
+            ->andWhere('fr.frequency_time IS NOT NULL AND fr.frequency_number IS NOT NULL');
         $q->andWhere(
             sprintf('NOT EXISTS (%s)', $subQuery->getSQL())
         );

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -153,7 +153,7 @@ class FrequencyRuleRepository extends CommonRepository
             ->join('ch', MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr', "ch.{$statContactColumn} = fr.lead_id");
 
         if ($channel) {
-            $q->andWhere('fr.channel = :channel or fr.channel is null')
+            $q->andWhere('fr.channel = :channel')
                 ->setParameter('channel', $channel);
         }
 
@@ -174,6 +174,8 @@ class FrequencyRuleRepository extends CommonRepository
         $q->having("count(ch.$statContactColumn) >= fr.frequency_number");
 
         $results = $q->execute()->fetchAll();
+        var_export($q->getParameters());
+        var_export($q->getSQL());
 
         return $results;
     }
@@ -241,6 +243,8 @@ class FrequencyRuleRepository extends CommonRepository
             $results[$key]['frequency_number'] = $defaultFrequencyNumber;
             $results[$key]['frequency_time']   = $defaultFrequencyTime;
         }
+        var_export($q->getParameters());
+        die(var_export($q->getSQL(), true));
 
         return $results;
     }

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -19,69 +19,46 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 class FrequencyRuleRepository extends CommonRepository
 {
     /**
-     * @param        $channel
-     * @param        $leadIds
-     * @param        $defaultFrequencyNumber
-     * @param        $defaultFrequencyTime
-     * @param string $statTable
-     * @param string $statSentColumn
-     * @param string $statContactColumn
+     * @param string      $channel
+     * @param array       $leadIds
+     * @param string|null $defaultFrequencyNumber
+     * @param string|null $defaultFrequencyTime
+     * @param string      $statTable
+     * @param string      $statSentColumn
+     * @param string      $statContactColumn
      *
      * @return array
      */
-    public function getAppliedFrequencyRules($channel, $leadIds, $defaultFrequencyNumber, $defaultFrequencyTime, $statTable = 'email_stats', $statContactColumn = 'lead_id', $statSentColumn = 'date_sent')
-    {
-        $q = $this->_em->getConnection()->createQueryBuilder();
-
-        $selectFrequency = ($defaultFrequencyNumber) ? 'IFNULL(fr.frequency_number,:defaultNumber) as frequency_number' : 'fr.frequency_number';
-        $selectNumber    = ($defaultFrequencyTime) ? 'IFNULL(fr.frequency_time,:frequencyTime) as frequency_time' : 'fr.frequency_time';
-
-        $q->select("ch.$statContactColumn, $selectFrequency, $selectNumber")
-            ->from(MAUTIC_TABLE_PREFIX.$statTable, 'ch')
-            ->leftJoin('ch', MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr', "ch.{$statContactColumn} = fr.lead_id");
-
-        if ($channel) {
-            $q->andWhere('fr.channel = :channel or fr.channel is null')
-                ->setParameter('channel', $channel);
-        }
-
-        if (!empty($defaultFrequencyTime)) {
-            $q->andWhere('ch.'.$statSentColumn.' >= case fr.frequency_time 
-                    when \'MONTH\' then DATE_SUB(NOW(),INTERVAL 1 MONTH) 
-                    when \'DAY\' then DATE_SUB(NOW(),INTERVAL 1 DAY) 
-                    when \'WEEK\' then DATE_SUB(NOW(),INTERVAL 1 WEEK)
-                    else DATE_SUB(NOW(),INTERVAL 1 '.$defaultFrequencyTime.')
-                    end')
-                ->setParameter('frequencyTime', $defaultFrequencyTime);
-        } else {
-            $q->andWhere('(ch.'.$statSentColumn.' >= case fr.frequency_time
-                     when \'MONTH\' then DATE_SUB(NOW(),INTERVAL 1 MONTH)
-                     when \'DAY\' then DATE_SUB(NOW(),INTERVAL 1 DAY)
-                     when \'WEEK\' then DATE_SUB(NOW(),INTERVAL 1 WEEK)
-                    end)');
-        }
-
+    public function getAppliedFrequencyRules(
+        $channel,
+        $leadIds,
+        $defaultFrequencyNumber,
+        $defaultFrequencyTime,
+        $statTable = 'email_stats',
+        $statContactColumn = 'lead_id',
+        $statSentColumn = 'date_sent'
+    ) {
         if (empty($leadIds)) {
-            // Preventative for fetching every single email stat
-            $leadIds = [0];
-        }
-        $q->andWhere(
-            $q->expr()->in("ch.$statContactColumn", $leadIds)
-        );
-
-        $q->groupBy("ch.$statContactColumn, fr.frequency_time, fr.frequency_number");
-
-        $havingAnd = 'AND '.$q->expr()->in("ch.$statContactColumn", $leadIds);
-        if ($defaultFrequencyNumber != null) {
-            $q->having("(count(ch.$statContactColumn) >= IFNULL(fr.frequency_number,:defaultNumber) $havingAnd)")
-                ->setParameter('defaultNumber', $defaultFrequencyNumber);
-        } else {
-            $q->having("(count(ch.$statContactColumn) >= fr.frequency_number $havingAnd)");
+            return [];
         }
 
-        $results = $q->execute()->fetchAll();
+        $violations = $this->getCustomFrequencyRuleViolations($channel, $leadIds, $statTable, $statContactColumn, $statSentColumn);
 
-        return $results;
+        if ($defaultFrequencyTime && $defaultFrequencyTime) {
+            $violations = array_merge(
+                $violations,
+                $this->getDefaultFrequencyRuleViolations(
+                    $leadIds,
+                    $defaultFrequencyNumber,
+                    $defaultFrequencyTime,
+                    $statTable,
+                    $statContactColumn,
+                    $statSentColumn
+                )
+            );
+        }
+
+        return $violations;
     }
 
     /**
@@ -97,11 +74,11 @@ class FrequencyRuleRepository extends CommonRepository
         $q->select(
             'fr.id, fr.frequency_time, fr.frequency_number, fr.channel, fr.preferred_channel, fr.pause_from_date, fr.pause_to_date, fr.lead_id'
         )
-          ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr');
+            ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr');
 
         if ($channel) {
             $q->andWhere('fr.channel = :channel')
-              ->setParameter('channel', $channel);
+                ->setParameter('channel', $channel);
         }
 
         $groupByLeads = is_array($leadIds);
@@ -112,7 +89,7 @@ class FrequencyRuleRepository extends CommonRepository
                 );
             } else {
                 $q->andWhere('fr.lead_id = :leadId')
-                  ->setParameter('leadId', (int) $leadIds);
+                    ->setParameter('leadId', (int) $leadIds);
             }
         }
 
@@ -154,6 +131,116 @@ class FrequencyRuleRepository extends CommonRepository
         }
 
         $results = $q->execute()->fetchAll();
+
+        return $results;
+    }
+
+    /**
+     * @param string $channel
+     * @param array  $leadIds
+     * @param string $statTable
+     * @param string $statContactColumn
+     * @param string $statSentColumn
+     *
+     * @return array
+     */
+    private function getCustomFrequencyRuleViolations($channel, array $leadIds, $statTable, $statContactColumn, $statSentColumn)
+    {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        $q->select("ch.$statContactColumn, fr.frequency_number, fr.frequency_time")
+            ->from(MAUTIC_TABLE_PREFIX.$statTable, 'ch')
+            ->join('ch', MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr', "ch.{$statContactColumn} = fr.lead_id");
+
+        if ($channel) {
+            $q->andWhere('fr.channel = :channel or fr.channel is null')
+                ->setParameter('channel', $channel);
+        }
+
+        $q->andWhere(
+            '(ch.'.$statSentColumn.' >= case fr.frequency_time
+                 when \'MONTH\' then DATE_SUB(NOW(),INTERVAL 1 MONTH)
+                 when \'DAY\' then DATE_SUB(NOW(),INTERVAL 1 DAY)
+                 when \'WEEK\' then DATE_SUB(NOW(),INTERVAL 1 WEEK)
+                end)'
+        );
+
+        $q->andWhere(
+            $q->expr()->in("ch.$statContactColumn", $leadIds)
+        );
+
+        $q->groupBy("ch.$statContactColumn, fr.frequency_time, fr.frequency_number");
+
+        $q->having("count(ch.$statContactColumn) >= fr.frequency_number");
+
+        $results = $q->execute()->fetchAll();
+
+        return $results;
+    }
+
+    /**
+     * @param array  $leadIds
+     * @param string $defaultFrequencyNumber
+     * @param string $defaultFrequencyTime
+     * @param string $statTable
+     * @param string $statContactColumn
+     * @param string $statSentColumn
+     *
+     * @return array
+     */
+    private function getDefaultFrequencyRuleViolations(
+        array $leadIds,
+        $defaultFrequencyNumber,
+        $defaultFrequencyTime,
+        $statTable,
+        $statContactColumn,
+        $statSentColumn
+    ) {
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
+
+        $q->select("ch.$statContactColumn")
+            ->from(MAUTIC_TABLE_PREFIX.$statTable, 'ch');
+
+        switch ($defaultFrequencyTime) {
+            case 'MONTH':
+                $since = new \DateTime('-1 month', new \DateTimeZone('UTC'));
+                break;
+            case 'WEEK':
+                $since = new \DateTime('-1 week', new \DateTimeZone('UTC'));
+                break;
+            case 'DAY':
+                $since = new \DateTime('-1 day', new \DateTimeZone('UTC'));
+                break;
+            default:
+                return [];
+        }
+
+        $q->andWhere('ch.'.$statSentColumn.' >= :frequencyTime')
+            ->setParameter('frequencyTime', $since->format('Y-m-d H:i:s'));
+
+        $q->andWhere(
+            $q->expr()->in("ch.$statContactColumn", $leadIds)
+        );
+
+        // Exclude contacts with custom rules defined
+        $subQuery = $this->getEntityManager()->getConnection()->createQueryBuilder();
+        $subQuery->select('null')
+            ->from(MAUTIC_TABLE_PREFIX.'lead_frequencyrules', 'fr')
+            ->where("fr.lead_id = ch.{$statContactColumn}");
+        $q->andWhere(
+            sprintf('NOT EXISTS (%s)', $subQuery->getSQL())
+        );
+
+        $q->groupBy("ch.$statContactColumn");
+
+        $q->having("count(ch.$statContactColumn) >= :defaultNumber")
+            ->setParameter('defaultNumber', $defaultFrequencyNumber);
+
+        $results = $q->execute()->fetchAll();
+        foreach ($results as $key => $result) {
+            $results[$key]['frequency_number'] = $defaultFrequencyNumber;
+            $results[$key]['frequency_time']   = $defaultFrequencyTime;
+        }
 
         return $results;
     }

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -174,8 +174,6 @@ class FrequencyRuleRepository extends CommonRepository
         $q->having("count(ch.$statContactColumn) >= fr.frequency_number");
 
         $results = $q->execute()->fetchAll();
-        var_export($q->getParameters());
-        var_export($q->getSQL());
 
         return $results;
     }
@@ -243,8 +241,6 @@ class FrequencyRuleRepository extends CommonRepository
             $results[$key]['frequency_number'] = $defaultFrequencyNumber;
             $results[$key]['frequency_time']   = $defaultFrequencyTime;
         }
-        var_export($q->getParameters());
-        die(var_export($q->getSQL(), true));
 
         return $results;
     }


### PR DESCRIPTION

Q | A
-- | --
Bug fix? | Y
New feature? |  
Automated tests included? |  
Related user documentation PR URL |  
Related developer documentation PR URL |  
Issues addressed (#s or URLs) |  
BC breaks? |  
Deprecations? |  

Description:
This improves the frequency rule query by breaking up into two queries, one for those with custom rules and one without. For the default rules, it allows to do simple calculations in PHP (such as the date) rather than asking MySQL to calculate on the fly.

Original (table with 133 million email stats): 32.8 seconds

```SELECT ch.lead_id, count(ch.lead_id) 
FROM mautic_email_stats ch 
WHERE (ch.date_sent >= '2018-11-08 21:23:54') AND (ch.lead_id IN (...)) 
GROUP BY ch.lead_id, fr.frequency_time, fr.frequency_number 
HAVING (count(ch.lead_id) >= fr.frequency_number AND ch.lead_id IN (...))
```
Broken into two queries: total 528.7ms
with custom rules: 49.7 ms

```
SELECT ch.lead_id, fr.frequency_number, fr.frequency_time 
FROM mautic_email_stats ch 
INNER JOIN mautic_lead_frequencyrules fr ON ch.lead_id = fr.lead_id 
WHERE fr.channel = 'email' AND ((ch.date_sent >= case fr.frequency_time
                 when 'MONTH' then DATE_SUB(NOW(),INTERVAL 1 MONTH)
                 when 'DAY' then DATE_SUB(NOW(),INTERVAL 1 DAY)
                 when 'WEEK' then DATE_SUB(NOW(),INTERVAL 1 WEEK)
                end)) AND (ch.lead_id IN (...)) 
GROUP BY ch.lead_id, fr.frequency_time, fr.frequency_number 
HAVING count(ch.lead_id) >= fr.frequency_number;
```

default for those without custom rules: 479ms

```
SELECT ch.lead_id
FROM mautic_email_stats ch 
WHERE (ch.date_sent >= '2018-11-08 21:23:54') AND (ch.lead_id IN (...)) 
    AND (NOT EXISTS (SELECT null FROM mautic_lead_frequencyrules fr WHERE fr.lead_id = ch.lead_id)) 
GROUP BY ch.lead_id 
HAVING count(ch.lead_id) >= 3;
```
Steps to test this PR:

1. Define a default email frequency rule in Mautic's configuration on the email settings tab
2. Go to the preference center for a single contact and define a different custom frequency rule (allow more than the default)
3. Add the contact above along with some others into a segment
4. Send emails to these contacts until they hit the frequency rule for both and emails are starting to queue
5. The contact with a custom frequency rule should not have had emails queued until it hit it's limit
6. All other contacts should have started queuing emails once it hit the limit as defined in Mautic's configuration
7. Repeat the test without a global configuration option set and a new contact with custom frequency rules and newly added to the segment)
8. Send emails again and this time only the contact with a custom frequency rule should have mail queued. The rest should be sent since there is no default.