### PR TITLE
Dispatch mail events from SendGridApiFacade

### DIFF
--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -455,6 +455,7 @@ return [
                     'mautic.transport.sendgrid_api.sendgrid_wrapper',
                     'mautic.transport.sendgrid_api.message',
                     'mautic.transport.sendgrid_api.response',
+                    'event_dispatcher',
                 ],
             ],
             'mautic.transport.sendgrid_api.mail.base' => [
@@ -479,7 +480,6 @@ return [
                     'mautic.transport.sendgrid_api.mail.personalization',
                     'mautic.transport.sendgrid_api.mail.metadata',
                     'mautic.transport.sendgrid_api.mail.attachment',
-                    'event_dispatcher',
                 ],
             ],
             'mautic.transport.sendgrid_api.response' => [

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/MailSendResponseEvent.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/Event/MailSendResponseEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Swiftmailer\SendGrid\Event;
+
+use SendGrid\Mail;
+use SendGrid\Response;
+use Swift_Mime_Message;
+
+class MailSendResponseEvent extends GetMailMessageEvent
+{
+    /** @var Response */
+    private $response;
+
+    /**
+     * Constructor.
+     *
+     * @param Response           $response
+     * @param Mail               $mail
+     * @param Swift_Mime_Message $message
+     */
+    public function __construct(Response $response, Mail $mail, Swift_Mime_Message $message)
+    {
+        $this->response = $response;
+
+        parent::__construct($mail, $message);
+    }
+
+    /**
+     * Get Response.
+     *
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
@@ -16,6 +16,7 @@ use Mautic\EmailBundle\Swiftmailer\Exception\SendGridBadRequestException;
 use Mautic\EmailBundle\Swiftmailer\SwiftmailerFacadeInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use SendGrid\Mail;
+use SendGrid\Response;
 
 class SendGridApiFacade implements SwiftmailerFacadeInterface
 {
@@ -71,6 +72,8 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
         } catch (SendGridBadRequestException $e) {
             throw new \Swift_TransportException($e->getMessage());
         }
+
+        $this->dispatchMailSendResponseEvent($response, $mail, $message);
     }
 
     /**
@@ -85,4 +88,19 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
 
         $this->dispatcher->dispatch(SendGridMailEvents::GET_MAIL_MESSAGE, $event);
     }
+
+    /**
+     * Dispatch MAIL_SEND_RESPONSE event.
+     *
+     * @param Response            $response
+     * @param Mail                $mail
+     * @param \Swift_Mime_Message $message
+     */
+    private function dispatchMailSendResponseEvent(Response $response, Mail $mail, \Swift_Mime_Message $message)
+    {
+        $event = new Event\MailSendResponseEvent($response, $mail, $message);
+
+        $this->dispatcher->dispatch(SendGridMailEvents::MAIL_SEND_RESPONSE, $event);
+    }
+
 }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
@@ -14,6 +14,8 @@ namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
 use Mautic\EmailBundle\Swiftmailer\Exception\SendGridBadLoginException;
 use Mautic\EmailBundle\Swiftmailer\Exception\SendGridBadRequestException;
 use Mautic\EmailBundle\Swiftmailer\SwiftmailerFacadeInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use SendGrid\Mail;
 
 class SendGridApiFacade implements SwiftmailerFacadeInterface
 {
@@ -32,14 +34,21 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
      */
     private $sendGridApiResponse;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
     public function __construct(
         SendGridWrapper $sendGridWrapper,
         SendGridApiMessage $sendGridApiMessage,
-        SendGridApiResponse $sendGridApiResponse
+        SendGridApiResponse $sendGridApiResponse,
+        EventDispatcherInterface $dispatcher
     ) {
         $this->sendGridWrapper     = $sendGridWrapper;
         $this->sendGridApiMessage  = $sendGridApiMessage;
         $this->sendGridApiResponse = $sendGridApiResponse;
+        $this->dispatcher          = $dispatcher;
     }
 
     /**
@@ -51,6 +60,8 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
     {
         $mail = $this->sendGridApiMessage->getMessage($message);
 
+        $this->dispatchGetMailMessageEvent($mail, $message);
+
         $response = $this->sendGridWrapper->send($mail);
 
         try {
@@ -60,5 +71,18 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
         } catch (SendGridBadRequestException $e) {
             throw new \Swift_TransportException($e->getMessage());
         }
+    }
+
+    /**
+     * Dispatch GET_MAIL_MESSAGE event.
+     *
+     * @param Mail                $mail
+     * @param \Swift_Mime_Message $message
+     */
+    private function dispatchGetMailMessageEvent(Mail $mail, \Swift_Mime_Message $message)
+    {
+        $event = new Event\GetMailMessageEvent($mail, $message);
+
+        $this->dispatcher->dispatch(SendGridMailEvents::GET_MAIL_MESSAGE, $event);
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiFacade.php
@@ -14,9 +14,9 @@ namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
 use Mautic\EmailBundle\Swiftmailer\Exception\SendGridBadLoginException;
 use Mautic\EmailBundle\Swiftmailer\Exception\SendGridBadRequestException;
 use Mautic\EmailBundle\Swiftmailer\SwiftmailerFacadeInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use SendGrid\Mail;
 use SendGrid\Response;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SendGridApiFacade implements SwiftmailerFacadeInterface
 {
@@ -102,5 +102,4 @@ class SendGridApiFacade implements SwiftmailerFacadeInterface
 
         $this->dispatcher->dispatch(SendGridMailEvents::MAIL_SEND_RESPONSE, $event);
     }
-
 }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridApiMessage.php
@@ -11,13 +11,11 @@
 
 namespace Mautic\EmailBundle\Swiftmailer\SendGrid;
 
-use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use SendGrid\Mail;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SendGridApiMessage
 {
@@ -41,23 +39,16 @@ class SendGridApiMessage
      */
     private $sendGridMailAttachment;
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-
     public function __construct(
         SendGridMailBase $sendGridMailBase,
         SendGridMailPersonalization $sendGridMailPersonalization,
         SendGridMailMetadata $sendGridMailMetadata,
-        SendGridMailAttachment $sendGridMailAttachment,
-        EventDispatcherInterface $dispatcher
+        SendGridMailAttachment $sendGridMailAttachment
     ) {
         $this->sendGridMailBase            = $sendGridMailBase;
         $this->sendGridMailPersonalization = $sendGridMailPersonalization;
         $this->sendGridMailMetadata        = $sendGridMailMetadata;
         $this->sendGridMailAttachment      = $sendGridMailAttachment;
-        $this->dispatcher                  = $dispatcher;
     }
 
     /**
@@ -73,21 +64,6 @@ class SendGridApiMessage
         $this->sendGridMailMetadata->addMetadataToMail($mail, $message);
         $this->sendGridMailAttachment->addAttachmentsToMail($mail, $message);
 
-        $this->dispatchGetMailMessageEvent($mail, $message);
-
         return $mail;
-    }
-
-    /**
-     * Dispatch GET_MAIL_MESSAGE event.
-     *
-     * @param Mail                $mail
-     * @param \Swift_Mime_Message $message
-     */
-    private function dispatchGetMailMessageEvent(Mail $mail, \Swift_Mime_Message $message)
-    {
-        $event = new GetMailMessageEvent($mail, $message);
-
-        $this->dispatcher->dispatch(SendGridMailEvents::GET_MAIL_MESSAGE, $event);
     }
 }

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
@@ -15,9 +15,9 @@ final class SendGridMailEvents
 {
     /**
      * The mautic.email.swiftmailer.sendgrid_api.get_mail_message event is
-     * dispatched by the mautic.transport.sendgrid_api.message service
-     * as the last step before returning a SendGrid\Mail instance in the
-     * getMessage method.
+     * dispatched by the mautic.transport.sendgrid_api.facade service
+     * immediately after obtaining a SendGrid\Mail instance from the
+     * mautic.transport.sendgrid_api.message service.
      *
      * The event listener receives an instance of
      * \Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent.

--- a/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
+++ b/app/bundles/EmailBundle/Swiftmailer/SendGrid/SendGridMailEvents.php
@@ -25,4 +25,17 @@ final class SendGridMailEvents
      * @var string
      */
     const GET_MAIL_MESSAGE = 'mautic.email.swiftmailer.sendgrid_api.get_mail_message';
+
+    /**
+     * The mautic.email.swiftmailer.sendgrid_api.mail_send_response event is
+     * dispatched by the mautic.transport.sendgrid_api.facade service
+     * after verifying the response from sending a SendGrid\Mail object via
+     * the mautic.transport.sendgrid_api.sendgrid_wrapper service.
+     *
+     * The event listener receives an instance of
+     * \Mautic\EmailBundle\Swiftmailer\SendGrid\Event\MailSendResponseEvent.
+     *
+     * @var string
+     */
+    const MAIL_SEND_RESPONSE = 'mautic.email.swiftmailer.sendgrid_api.mail_send_response';
 }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/GetMailMessageEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/GetMailMessageEventTest.php
@@ -16,8 +16,8 @@ use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiFacade;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiResponse;
-use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridWrapper;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridWrapper;
 use SendGrid\Mail;
 use SendGrid\Response;
 use Swift_Mime_Message;
@@ -102,9 +102,9 @@ class GetMailMessageEventTest extends \PHPUnit_Framework_TestCase
     /**
      * Create sendgrid api facade.
      *
-     * @param Mail                      $mail
-     * @param Swift_Mime_Message        $message
-     * @param EventDispatcherInterface  $dispatcher
+     * @param Mail                     $mail
+     * @param Swift_Mime_Message       $message
+     * @param EventDispatcherInterface $dispatcher
      *
      * @return SendGridApiFacade
      */
@@ -140,7 +140,6 @@ class GetMailMessageEventTest extends \PHPUnit_Framework_TestCase
 
         return new SendGridApiFacade($wrapper, $apiMessage, $apiResponse, $dispatcher);
     }
-
 }
 
 /**

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
@@ -71,8 +71,8 @@ class MailSendResponseEventTest extends \PHPUnit_Framework_TestCase
     /**
      * Create SendGridApiFacade and send message with specified success.
      *
-     * @param EventDispatcherInterface  $dispatcher
-     * @param bool                      $success    Whether response is successful
+     * @param EventDispatcherInterface $dispatcher
+     * @param bool                     $success    Whether response is successful
      */
     protected function createFacadeAndSendMessage(
         EventDispatcherInterface $dispatcher,
@@ -118,7 +118,6 @@ class MailSendResponseEventTest extends \PHPUnit_Framework_TestCase
 
         $apiFacade->send($message);
     }
-
 }
 
 /**
@@ -172,5 +171,4 @@ class TestMailSendResponseSubscriber implements EventSubscriberInterface
     {
         return $this->response;
     }
-
 }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * @copyright   2019 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid\Event;
+
+use Mautic\EmailBundle\Swiftmailer\Message\MauticMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\MailSendResponseEvent;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiFacade;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiResponse;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
+use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridWrapper;
+use Monolog\Logger;
+use SendGrid\Mail;
+use SendGrid\Response;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MailSendResponseEventTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests that a subscriber to the SendGridMailEvents::MAIL_SEND_RESPONSE
+     * event will be called when the facade gets a valid response and that the
+     * response is made available to the subscriber.
+     */
+    public function testValidMailSendResponse()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = new TestMailSendResponseSubscriber();
+        $dispatcher->addSubscriber($subscriber);
+
+        $response = new Response(200, 'Good Request');
+
+        $this->createFacadeAndSendMessage($dispatcher, $response);
+
+        $this->assertTrue($subscriber->wasCalled());
+        $this->assertSame($subscriber->getResponse(), $response);
+        $this->assertEquals($subscriber->getResponse()->statusCode(), 200);
+        $this->assertEquals($subscriber->getResponse()->body(), 'Good Request');
+    }
+
+    /**
+     * Tests that a subscriber to the SendGridMailEvents::MAIL_SEND_RESPONSE
+     * event will not be called when the facade gets a failed response.
+     */
+    public function testFailedMailSendResponse()
+    {
+        $dispatcher = new EventDispatcher();
+        $subscriber = new TestMailSendResponseSubscriber();
+        $dispatcher->addSubscriber($subscriber);
+
+        $response = new Response(400, json_encode(['errors' => [['message' => 'Bad Request']]]));
+
+        $this->expectException(\Swift_TransportException::class);
+        $this->expectExceptionMessage('Bad Request');
+
+        $this->createFacadeAndSendMessage($dispatcher, $response);
+
+        $this->assertFalse($subscriber->wasCalled());
+    }
+
+    /**
+     * Create SendGridApiFacade and send message with specified success.
+     *
+     * @param EventDispatcherInterface  $dispatcher
+     * @param bool                      $success    Whether response is successful
+     */
+    protected function createFacadeAndSendMessage(
+        EventDispatcherInterface $dispatcher,
+        Response $response
+    ) {
+        $wrapper = $this->getMockBuilder(SendGridWrapper::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $wrapper
+            ->method('send')
+            ->willReturn($response);
+
+        $message = $this->getMockBuilder(MauticMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mail = $this->getMockBuilder(Mail::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $apiMessage = $this->getMockBuilder(SendGridApiMessage::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $apiMessage
+            ->method('getMessage')
+            ->with($message)
+            ->willReturn($mail);
+
+        $logger = $this->getMockBuilder(Logger::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $apiResponse = new SendGridApiResponse($logger);
+
+        $apiFacade = new SendGridApiFacade(
+            $wrapper,
+            $apiMessage,
+            $apiResponse,
+            $dispatcher
+        );
+
+        $apiFacade->send($message);
+    }
+
+}
+
+/**
+ * Test subscriber records whether it was called.
+ */
+class TestMailSendResponseSubscriber implements EventSubscriberInterface
+{
+    /** @var bool */
+    protected $called = false;
+
+    /** @var Response */
+    protected $response;
+
+    /**
+     * Get subscribed events.
+     *
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            SendGridMailEvents::MAIL_SEND_RESPONSE => ['onSendMailResponse', 0],
+        ];
+    }
+
+    /**
+     * @param MailSendResponseEvent $event
+     */
+    public function onSendMailResponse(MailSendResponseEvent $event)
+    {
+        $this->called   = true;
+        $this->response = $event->getResponse();
+    }
+
+    /**
+     * Was called.
+     *
+     * @return bool
+     */
+    public function wasCalled(): bool
+    {
+        return $this->called;
+    }
+
+    /**
+     * Get response.
+     *
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+}

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/Event/MailSendResponseEventTest.php
@@ -158,7 +158,7 @@ class TestMailSendResponseSubscriber implements EventSubscriberInterface
      *
      * @return bool
      */
-    public function wasCalled(): bool
+    public function wasCalled()
     {
         return $this->called;
     }

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiFacadeTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiFacadeTest.php
@@ -19,6 +19,7 @@ use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiResponse;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridWrapper;
 use SendGrid\Mail;
 use SendGrid\Response;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,6 +37,10 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -48,7 +53,7 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse);
+        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse, $dispatcher);
 
         $sendGridApiMessage->expects($this->once())
             ->method('getMessage')
@@ -81,6 +86,10 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -93,7 +102,7 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse);
+        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse, $dispatcher);
 
         $sendGridApiMessage->expects($this->once())
             ->method('getMessage')
@@ -130,6 +139,10 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->getMockBuilder(EventDispatcher::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $message = $this->getMockBuilder(\Swift_Mime_Message::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -142,7 +155,7 @@ class SendGridApiFacadeTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse);
+        $sendGridApiFacade = new SendGridApiFacade($sendGridWrapper, $sendGridApiMessage, $sendGridApiResponse, $dispatcher);
 
         $sendGridApiMessage->expects($this->once())
             ->method('getMessage')

--- a/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
+++ b/app/bundles/EmailBundle/Tests/Swiftmailer/SendGrid/SendGridApiMessageTest.php
@@ -11,15 +11,12 @@
 
 namespace Mautic\EmailBundle\Tests\Swiftmailer\SendGrid;
 
-use Mautic\EmailBundle\Swiftmailer\SendGrid\Event\GetMailMessageEvent;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailAttachment;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailBase;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailMetadata;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\Mail\SendGridMailPersonalization;
 use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridApiMessage;
-use Mautic\EmailBundle\Swiftmailer\SendGrid\SendGridMailEvents;
 use SendGrid\Mail;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,8 +38,6 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $dispatcher = $this->createMock(EventDispatcher::class);
-
         $mail = $this->getMockBuilder(Mail::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -51,7 +46,7 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment, $dispatcher);
+        $sendGridApiMessage = new SendGridApiMessage($sendGridMailBase, $sendGridMailPersonalization, $sendGridMailMetadata, $sendGridMailAttachment);
 
         $sendGridMailBase->expects($this->once())
             ->method('getSendGridMail')
@@ -69,13 +64,6 @@ class SendGridApiMessageTest extends \PHPUnit_Framework_TestCase
         $sendGridMailAttachment->expects($this->once())
             ->method('addAttachmentsToMail')
             ->with($mail, $message);
-
-        $dispatcher->expects($this->once())
-            ->method('dispatch')
-            ->with(
-                $this->equalTo(SendGridMailEvents::GET_MAIL_MESSAGE),
-                $this->isInstanceOf(GetMailMessageEvent::class)
-            );
 
         $result = $sendGridApiMessage->getMessage($message);
 


### PR DESCRIPTION
| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | Y
| Automated tests included? | Y
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | Maybe
| Deprecations? | N

#### Description:

This feature improves and extends the functionality previously merged in PR #140 (`feature/sendgrid-mail-event`) by moving the event dispatching from the **SendGridApiMessage** service to the **SendGridApiFacade** and also providing event-based access to the SendGrid API mail send response.

The `SendGridMailEvents::GET_MAIL_MESSAGE` event is now dispatched immediately after the **Mail** instance is returned by **SendGridApiMessage**.

There is now another event, `SendGridMailEvents::MAIL_SEND_RESPONSE`, which is dispatched after the message has been sent and a **SendGrid\Response** has been received and validated. The event object passed to subscribers is an instance of **GetMailMessageEvent**, which allows access to the Response by way of its `getResponse()` method. This event class extends the previously defined **GetMailMessageResponse** and thereby allows access to the same _mail_ and _message_ objects.

#### Steps to test this PR:

##### PHPUnit

1.  Test that subscribers to both new events are called as expected:
    `$ bin/phpunit --configuration app/phpunit.xml.dist --filter '/SendGrid.*EventTest/'`

#### List backwards compatibility breaks:

1. An **EventDispatcher** must be passed via constructor injection to the **SendGridApiFacade** class. A constructor argument has been added as well as the relevant service configuration changes. Any use of the **SendGridApiFacade** class not covered by the scope of this codebase may be subject to breakage.
2. The aforementioned service constructor argument change and configuration edits will require the application kernel cache to be cleared and rebuilt. Probably a good idea to wipe the APC cache if applicable.
