### PR TITLE
removes most of the long running dashboard elements

### DIFF
--- a/media/dashboards/default.json
+++ b/media/dashboards/default.json
@@ -4,16 +4,6 @@
     "widgets":
     [
         {
-            "name": "Contacts Created",
-            "width": 100,
-            "height": 330,
-            "ordering": 0,
-            "type": "created.leads.in.time",
-            "params": {
-                "lists": "identifiedVsAnonymous"
-            }
-        },
-        {
             "name": "Page Visits",
             "width": 50,
             "height": 330,
@@ -29,20 +19,6 @@
             "height": 330,
             "ordering": 2,
             "type": "submissions.in.time"
-        },
-        {
-            "name": "Recent Activity",
-            "width": 50,
-            "height": 330,
-            "ordering": 3,
-            "type": "recent.activity"
-        },
-        {
-            "name": "Upcoming Emails",
-            "width": 50,
-            "height": 330,
-            "ordering": 4,
-            "type": "upcoming.emails"
         }
     ]
 }


### PR DESCRIPTION
**Please be sure you are submitting this against the _staging_ branch.**

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | N
| New feature? | N
| Automated tests included? | N
| Related user documentation PR URL | N
| Related developer documentation PR URL | N
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description:
updates default dashboard template to not include widgets that take forever to load

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. load the dashboard
2. wait forever

#### Steps to test this PR:
1. clear your cookies and remove any dashboard configuration from `mautic_db.widgets`
2. see how fast?!

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 
